### PR TITLE
Add support for `fit`/`predict` in `GroupedPipeline`

### DIFF
--- a/docs/source/examples/GroupedPipeline.ipynb
+++ b/docs/source/examples/GroupedPipeline.ipynb
@@ -1,0 +1,378 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# `GroupedPipeline`: applying a transformer per category"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "from sklearn.datasets import load_iris\n",
+    "from sklearn.pipeline import Pipeline\n",
+    "from sklearn.linear_model import LinearRegression\n",
+    "from sklearn.metrics import mean_squared_error as mse, mean_absolute_error as mae\n",
+    "\n",
+    "from timeserio.data.datasets import load_iris_df\n",
+    "from timeserio.pipeline import GroupedPipeline\n",
+    "from timeserio.preprocessing import PandasValueSelector\n",
+    "\n",
+    "import seaborn as sns"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load the iris dataset\n",
+    "\n",
+    "This dataset consists of four numeric and one categorical columns."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>sepal_length_cm</th>\n",
+       "      <th>sepal_width_cm</th>\n",
+       "      <th>petal_length_cm</th>\n",
+       "      <th>petal_width_cm</th>\n",
+       "      <th>species</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>5.1</td>\n",
+       "      <td>3.5</td>\n",
+       "      <td>1.4</td>\n",
+       "      <td>0.2</td>\n",
+       "      <td>setosa</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>4.9</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>1.4</td>\n",
+       "      <td>0.2</td>\n",
+       "      <td>setosa</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   sepal_length_cm  sepal_width_cm  petal_length_cm  petal_width_cm species\n",
+       "0              5.1             3.5              1.4             0.2  setosa\n",
+       "1              4.9             3.0              1.4             0.2  setosa"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df = load_iris_df()\n",
+    "df.head(2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Imagine we want to predict `sepal_width_cm` based on `sepal_length_cm`: we may try fitting a simple linear regression model. The result is somewhat unsatisfying:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fit a joint model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<seaborn.axisgrid.FacetGrid at 0x7f600c6d2ba8>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWAAAAFgCAYAAACFYaNMAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAgAElEQVR4nO3dfZhkdX3n/ff31EM/zfMwA6MzOqAIAUWE0QASboK4q9GdxOil5NoYcUMwxgQ062Y32WvVe5KNtxs3CnHvKDeJiw+RKJHsmKhRMkFCFGRmJCBCcMKgDAIzzAwzPf1YVed7/3FOVVfXdNdDV506VdWf13X1Vd2nzsOvTlV/+/T5/b7fn7k7IiLSfUHaDRARWa4UgEVEUqIALCKSEgVgEZGUKACLiKREAVhEJCVdCcBmljGz75nZ3yzw3NVmdsjM7o+/rulGm0RE0pbt0nGuBx4GVi3y/F+6+282u7PXve51/vWvf70jDRMR6QJbaGHiV8Bmthl4A3Bzp/b57LPPdmpXIiKp6cYtiI8DvwOEddZ5s5k9YGa3mdmWhVYws2vNbLeZ7T506FAiDRUR6aZEA7CZvRE46O576qz2FWCru58HfBO4ZaGV3P0md9/m7ts2bNiQQGtFRLor6SvgVwPbzexx4FbgCjP7XPUK7n7Y3WfiH28GLky4TSIiPSHRAOzuv+vum919K3AVsMvdf7l6HTPbVPXjdqLOOhGRgdetURDzmNkOYLe77wSuM7PtQBE4AlydRptERLrN+rEc5bZt23z37t1pN0NEpFnpDEMTEZGFKQCLiKREAVhEJCWpdMKJLObORw7yqbse44mjk2xZO8q7LjuDy8/emHazRBKhK2DpGXc+cpAP7HyIg+PTrBnJcXB8mg/sfIg7HzmYdtNEEqEALD3jU3c9Ri5jjOazmEWPuYzxqbseS7tpIolQAJae8cTRSUZymXnLRnIZDhydTKlFIslSAJaesWXtKFOF0rxlU4USm9eOptQikWQpAEvPeNdlZ1AoOZOzRdyjx0LJeddlZ6TdNJFEKABLz7j87I3s2H4uG1cOc2yqwMaVw+zYfq5GQcjA0jA06SmXn71RAVeWDV0Bi4ikRAFYRCQlCsAiIilRABYRSYkCsIhIShSARURSogAsIpISBWARkZQoAIuIpEQBWEQkJQrAIiIpUQAWEUmJArCISEoUgEVEUqIALCKSEtUDlo7T1PIizdEVsHSUppYXaZ4CsHSUppYXaZ4CsHSUppYXaZ4CsHSUppYXaZ4CsHSUppYXaZ4CsHSUppYXaZ6GoUnHaWp5keboClhEJCUKwCIiKVEAFhFJie4BL2NKGRZJl66AlymlDIukTwF4mVLKsEj6FICXKaUMi6RPAXiZUsqwSPoUgJcppQyLpE8BeJlSyrBI+jQMbRlTyrBIunQFLCKSEgVgEZGUKACLiKREAVhEJCVd6YQzswywG3jS3d9Y89wQ8BngQuAw8DZ3f7wb7ZL+otoVMmi6dQV8PfDwIs/9KnDU3V8MfAz4SJfaJH1EtStkECUegM1sM/AG4OZFVvl54Jb4+9uA15iZJd0u6S+qXSGDqBtXwB8HfgcIF3n++cATAO5eBI4B62tXMrNrzWy3me0+dOhQUm2VHqXaFTKIEg3AZvZG4KC772l3X+5+k7tvc/dtGzZs6EDrpJ+odoUMoqSvgF8NbDezx4FbgSvM7HM16zwJbAEwsyywmqgzTqRCtStkECUagN39d919s7tvBa4Cdrn7L9esthN4R/z9W+J1PMl2Sf9R7QoZRKnUgjCzHcBud98J/BnwWTPbBxwhCtQiJ1HtChk01o8Xm9u2bfPdu3en3QwRkWYtOLJLmXAiIilRABYRSYkCsIhISlSQXVp24x2PcvPd+5mYLTGWz3DNpadz3ZUvSbtZIn1HAVhacuMdj3LDrn0EBtkgSoa4Ydc+AAVhkRbpFoS05Oa798fBNyCwIH6MlotIaxSApSUTsyWCmgE1gUXLRaQ1CsDSkrF8hrBm6Hjo0XIRaY0CsLTkmktPJ3QohiGhh/FjtFxEWqNOOGlJuaNNoyBE2qdUZBGR5CkVWUSklygAi4ikRAFYRCQl6oQbYO+7dS87H3iaUuhkAmP7eafxsasuSLtZdWnqeemkdj5P3fgs6gp4QL3v1r3cfv9TlOJBu6XQuf3+p3jfrXtTbtniNPW8dFI7n6dufRYVgAfUzgeeBsBs7qt6eS/S1PPSSe18nrr1WVQAHlCl2nS1Bst7gaael05q5/PUrc+iAvCAytQWbGiwvBdo6nnppHY+T936LCoAD6jt550GgPvcV/XyXqSp56WT2vk8deuzqAA8oD521QW86fxNlSveTGC86fxNPT0KQlPPSye183nq1mdRqcgiIslTKrKISC9RABYRSYkCsIhIShSARURSoloQAyypPHjVaxDpDI2CGFDlXPZcxhjJZZgqlCiUvKmhNPW2BZa8X5FlTKMglpOk8uBVr0Gkc3QLYkA9cXSSNSO5ectayYNfbFuHJe9XRObTFfCASioPXvUaRDpHAXhAJZUHr3oNIp2jWxAD6vKzN7KD6H7ugaOTbG5htEKjbZe6XxGZT6MgRESSp1EQIiK9RAFYRCQlCsAiIilRJ1yHJJWe22i/SguWXqHPYut0BdwBSU1h3Wi/msZdeoU+i0ujANwBSaXnNtqv0oKlV+izuDQKwB2Q1BTWjfaradylV+izuDQKwB2QVHpuo/0qLVh6hT6LS6MA3AFJpec22q/SgqVX6LO4NMqE65ByD3Cn03Mb7Tep44q0Sp/FuhbMhFMAFhFJnlKRRUR6iQKwiEhKFIBFRFKiACwikpJEa0GY2TBwFzAUH+s2d/9gzTpXA38EPBkv+oS735xkuwbJjXc8ys1372ditsRYPsM1l57OdVe+pOFzkF79ChGJNB2AzWwN8CvA1urt3P26OpvNAFe4+wkzywF3m9nX3P2emvX+0t1/s/lmC0QB9oZd+wgMskE08P2GXfsqzy/23HVXvmTe1PPVufs7oK1gmdR+RQZRK7cgvkoUfB8E9lR9LcojJ+Ifc/FX/41761E3370/DrABgQXxY7S83nOQXv0KEZnTyi2IYXf/7VYPYGYZokD9YuB/ufu9C6z2ZjO7DHgUeJ+7P7HAfq4FrgV4wQte0GozBtLEbIlszZ/QwKLlQN3n2pm2vp6k9isyiFq5Av6smf2amW0ys3Xlr0YbuXvJ3c8HNgOvMrOX1qzyFWCru58HfBO4ZZH93OTu29x924YNG1po9uAay2cIa/6fCD1aXu85SK9+hYjMaSUAzxJ1ln2HudsPTaejuftzwD8Ar6tZftjdZ+IfbwYubKFNy9o1l55O6FAMQ0IP48doeb3nIL36FSIyp5VbEP8ReLG7P9vsBma2ASi4+3NmNgK8FvhIzTqb3P2p+MftwMMttGlZK49oqDfSYbHn2pm2vp6k9isyiJquBWFm3wB+wd2bvplnZucR3VLIEF1tf9Hdd5jZDmC3u+80sw8TBd4icAR4t7s/Um+/qgUhIn2mvWI8ZnY7cC7RbYTyLYNGw9ASoQAsIn1mwQDcyi2Iv46/RESkA1oJwLcB0+5egsrwsqFEWiUisgy0EoD/HrgSKCdWjADfAC7pdKP6UTvpt41Shpe6bVJT2rfT3rS08/7U21Zp19KOVu4B3x+P5627rBt67R5wdfrtSC7DVKFEoeTs2H5uw1/G6nTiwKKxuqHD9Ve8uGFQq7fteZvX1G3TUtvcTnvT0s77U29bYMn7lWWn7YLsE2Z2QWVvZhcCU+22ahC0k37bKGV4qdsmNaV9O+1NSzvvT71tlXYt7WrlFsR7gS+Z2U+IovlpwNsSaVWfaSf9tlE68VK3bdSmpba5nfampZ33p962Dkq7lrY0fQXs7vcBZwPvBn4d+Cl3rxTjMbPXdr55/aGd9NtGKcNL3TapKe3baW9a2nl/6m2rtGtpV0sF2d294O7fj78KNU9/ZMGNloF20m8bpQwvddukprRvp71paef9qbet0q6lXR2bFdnMvufur+jIzhrotU44aG9K7qRHQXR6Svt+HgWxlPen3raail2alOy09Ga2190vaLxm+3oxAIuI1KFp6UVEekknA/DjHdyXiMjAa2lSTjO7hJPnhPtM/PiLHW2ZiMiAa2VSzs8CLwLuB8pjbxz4TALtqqtQCnnm+DRD2YChbIahbEAQLHiLRUSkZ7VyBbwNOMc71WvXBneYmCkyMTO3LJcJGMrNBeShbIDZ4Adl1SlIV1ojQvpxJIqcrJUA/H2i7LenGq2YhkIppFAKOUERADOrBOKhXBSUc5nB6nOsNwU8oOnhE1ZdFyMbREkYN+zaB5BoMEzruNJ5DQOwmX2F6FbDSuAHZvZd5hdk355c85bO3ZkulJgulGAqyhnJBEY+vm2RzwbkMwH52rzaPlJdiwBgNJ9lcrZYqUWw2HMKwJ1RXRcDopTsYhhy8937Ew2EaR1XOq+ZK+CPJt6KLimFztRsiamqugWBRUE5nw0Y7rMrZdUpSFdadTH6sR6HLKxhAHb3bwGY2Ufc/T9XP2dmHwG+lVDbuiKsulI+Hl8pZ4PofvJwNsNQLrpS7sVOvi1rRzk4Pl25yoX5tQjqPSftG8tHJSirPxrdqIuR1nGl81q51Fuo2M7rO9WQXlIMQyZmihyemOEnz03x+OEJnjgyycHxaY5NFpiaLVGqrUiTAtUpSFdadTH6sR6HLKyZe8DvBn4DOMPMHqh6aiXwT0k1rNfUdvJBdKVcvn2Rxj3lRlPAa3r4ZJXvt3Z7NEJax5XOa1gLwsxWA2uBDwP/peqpcXc/kmDbFnXe+Rf4X3/zrjQO3ZCZkcsY+Ux0L7kcnPvlvrKIJGLJsyJngOPAe07ao9m6tIJwr3J3ZovObDGct7x6BMaQgrKI0FwA3kM0DM2AFwBH4+/XAD8GdOOpCQuNwMgENjckbgCGxYlIa5oZBXE6gJn9f8Dt7v7V+OfXA7+QbPMGWymMOscmZ+eWWXlYXJzZl88sn6w+keWmlUy4i9z918o/uPvXzOx/JNCm1Hz3sSPcet8TPHV8ik2rRrjqlVt41Rnr2t72s99+nC/uOcBUocRILsNbL9zM2y/ZuuB+3J2ZQomZQonx6WhZ+b7ycC7DcC4T3182zEzpxrFePQ/NFMzvdJsb7Tep9PVefQ96WSvT0v8d8I/A5+JF/x64zN3/bUJtW1QSnXDffewIN+z6IdnAGM4FTBdCiqFz/RVnNgzC9bb9l6ePc8s9PyIwMIvqWIQO77johYsG4WaYGbv3H+Fjf/8o+UzASC7DTLFEMWTZTYvezrTzSapOGQ4set9Dh+uveDHnbV6TSJsbnYt6zwNLblOvvgc9pO2C7L8EbABuj782xssGwq33PUE2iD48RvSYDYxb73uirW2/uOcAgUEmnsY9E0/j/sU9B9pqr7vz+Xt/TMaiERel0OPUVOdPdu3j+HSB6UKJHqidlLhenR6+OmU4sCB+jJYn1eZG+633fDtt6tX3oNc1fQsiHu1wfYJtSdVTx6dYNTz/dAznAp4+PtXWtlOFErWDHcw4aTbdTrV5KBvw5HOTPDs+VyquPBwuF9+6yGUCsoGRHZBRGO1MO5+keinDSbW50X6TSl/v1feg1zWTiPFxd39vVVGeeXq1GE+rNq0a4fDEDCO5uXTO6ULIaatG2tp2fLrITLE07x8Qd+atm3Sby0kktarrYFQ6/vqww69RSnZa6qUMJ9XmRvtNKn29V9+DXtfMJdBn48ePAv9zga+BcNUrt1AMnalCCSd6LIbOVa/c0ta2b71wM6FDKU4bLcVpo2+9cHOqbYa5OhjHpwo8O15Ou57kwNEo7fq5ydmeSbuup1fTruulDCfV5kb7TSp9vVffg17XSifca4Bvu3vj/8kTtmrLWf66//pp1o0NsX5FnrWjedavyLNuNM+6FXnWj+UZXsIVZnkkw9PHpzhtiaMgFtq2lVEQ3WxzK8pp17mMzbti7pWr5V6dHr6ZURCdbnOj/dZ7vp029ep70CPam5bezG4BLgaOEI2GuAu4292PdqqFzRradKZvesfH664zms+wbiwKxuvir+rvo5+HWDmSJeiRINJvKmnX2YChTIZcNuoQHJR7yyId1F4Armxg9jzgLcD7gee5e0sTe3bC5jNf6r/0h5/n8MQsRyZmOToxy+GJWU7MFBtvXCMbGGurrpzXj+VZu0CwXjeWV+pwk8pXy0PZgFz5qrmHrpZFUrDkWhDR1ma/DPwM8DLgWeATRFfCXbduLM+7L3/RSctnCiWOTM5y+MQsRybnAvOR+OfDJ+KAPTlL+bZmMXQOnZjh0ImZk/ZXa9Vwdu5KesUQ60ZzrFsxdFKwHstnlnWwKYYhxdlwXoYfRIE5G4/CyFUe55JKRJabVq5ePw78K/BJ4B/c/fFEWtSGoVyGTatH2LS6/siFUugcmypwJL6CLn8dnpjl8MRMJWAfOTHLdFVRnePTRY5PF3n8cP2hNUPZYMHbHtVX1+tXDLF6JEemBwu9J6UYhhRDommiqpgZ2cAqs5Hk4vvLCswy6FoZB3yKmZ0LXAb8dzM7E/gXd397Yq1LSCawSlCsJ+rNLc0L0LVBu7z8WDybBsBMMeSpY9M8dWy67v4DgzWj8zsP140tfM96KZ2K/cLdKZR8waFyuUzVVXMQkMvOXTmL9LtWbkGsIqqG9kJgK7AaOPk3ZoCYGWNDWcaGsmxZV38843f2Hebz9/6Yp8enWD2c5/wta1g1kq1cSVfuV0/OUihF9z9CpxLEOdREe4BTVw3xU5tWnXQrZP2KIdaN5Vk1nB2oq8ZoDDNMsfBVczZjBBZ9ZQMjCKLHTBAF6rT/w0iqPsL7bt3LzgeephQ6mcDYft5pfOyqCxLfVjqrlVEQDwB3x193uXt7ubRt6LWC7K3UkXB3jk8XK4H3vv1H+NpDT1dShgslpxg6uYwxXWj971u26up+3u2PeLhe9a2Q5XAVWQ7UmeDkAB3Y3GNUr8E6OvdfUvUR3nfrXm6//6mTlr/p/E0NA2k720pb2uuEc/fz6u7d7E/c/bdabdUgqK4FAVR+2W6974mTArCZsXokx+qRHKefMsbn7/kxa0Zy87LZpgol1o8N8egzx5kphgSBUf47Wb5qufCFazkcjwCp7VQ8OD7DwfHmOhXLV87VAbv2VshoH3cqzt3eaH6bSlAOjEwcnK0SrCEoB28zggAytnBad3V9BIDRfJbJ2SKfuuuxtgLwzgeeBqKU9rnXGS3/2FXJbSud18khZK/u4L76SlJ1JKaLIZkgujIr//00c0qh8+FffFll/epOxepOxPKoj+r71zMLdCruf3aibhuHswHrqhJd1pUTX8aGWDeWY/1YFMQHpVOxFDolHFos11EO3BZfTT9+eIJVw9nKvW0DcoHxo8MTHJsqkAnmgvhcQG98/hbLTGwmY7GdbaXzuj6GdxClXUeiulPxxaxY9Fi1nYrVgbm2g7G6U3G6GPKT56b5yXONOxXXjlaN9KgeU10duEfzDA1gp2IlcMdOXTl80ns7VSixceUwh+sMeyzf07bKH93oCtwqz0X9B7V3DwODY5Nz7xtV2weV7RffthQ67l45VvVVspmdVFmv3/4rcvf4tUevY7E/OVHJ2OjZUuiE7oQhOI57tF1lX3hlRx5vW7veWD7L2kU6/BWAO+CqV27hhl0/ZKpQmncPuNk6EottW64lTBjOqyW81DoSrXQqFkohRyfmrqSPLnJFfWRilmI416l4OH5uX4O2jA1l4ivn3Fwq+djQSYF7ZR93Ki71cxG6VwLAQq44awN3PHJyr+0VZ23g8ET9W0/1tv3R4fr/CdVTfo/Kgduw+A8HlT8mRvTHY97dUJ8fuEKHsOZq3H3+H4NGFgqCaRrKLn78ljPhFt2R2ffc/RUd2VkDvdYJB/1ZR6ITajsVo8SXmQUD98Rs6yU4cxk7qdbH3C2QuZTytaO5nkyBTqpWxx/+7Q/Y9S+HCD26er3irA383hvOSXxbad3K4RwbVg51JhV5MWZ2tbv/747srIFeDMDS2HRh4dsfc4E7uuJ+rqpTsRWrR3ILppKXb4Gsj4P1SH7wbn9I76oXgJupB7xgHeCycj3gbgVf6V/DuQzPWzPC89Y0zlR8bnKRIF3zVd2peGyqEN27btSpmAuqRnsMLZqxuGY0p0JNkqhm7gF/NPFWiFTJBMb6FUOsXzHEmXXWc3cmqjMVKynkMxyZLHDkxEwlaB+fnivUNF1orVOxPI66OmNxrqMxCuD52qkvRJrQzLT03+pGQ0RaZWasGMqyYijLC5roVFwohXx+4I4eSwt0Kv7wYP22rBjKLppGXn0LZMVQ/3YqSue1kop8JvBh4BxguLzc3RcteW9mw0R1g4fiY93m7h+sWWcI+AxwIXAYeFsvFvqR/pbLBJy6aphTVw3XXS90Z3yqyOGJmUqiy2K3QiarOhVPzBQ5MVPkx0fqF2rKZWzebY75t0LmxlT3aqeidFYrw9A+DXwQ+Bjws8A7aTyl0QxwhbufMLMccLeZfc3d76la51eBo+7+YjO7CvgI8LYW2tWScq/0U8en2FTTK13vuSTVG+nQqE1ptLmdYzYa1bHUfbez38W2PWND/WNOlTsVqxJf5kZ9zHBkosDhiRmemyxUOlEKJeeZ4zM8c7z+cDGDSlLLSC7Dmaeu4CWnrqzcCtn9+BHufPQQ04WQ0Xxrn5l29OLvTy+2qVmt1ILY4+4XmtmD7v6y6mVNbj9KVEfi3e5+b9XyvwM+5O7fMbMs8DSwwes0bKmjIOrVbACarufQSZ/99uPccs+P4nTXubG+77johZx12qq6bWqlBkWntHPMeq/17ZdsXfK+29lveaz1Ytt2QrlTsfoq+st7D/DYs52dMfjUlUNsXDXMvx46QS5jDGcD4rpP/PplL+Lysze01anYi78/vdimWm2NgqgyY2YB8EMz+03gSaiTdhUzswywB3gx8L+qg2/s+cATAO5eNLNjwHqiou8dVa9mA9B0PYeq11b5PqgZfL5QNlFlu3gkuhl8ae8BAouKlcdPUgxDvrT3AGeduop81hjJRW/T2FDAVKHIl/Yc4IpzNvKlPQcWff4155xa91x4fE1WaXOd11bttr0HGMoGlfNUfcyf/amNlSyi8gB497nMoi/uiV5rpuq1EoZ8cc8B3n7J1pZqalRrZ78/PDhed9tOqO5ULPvjbz664LoGnHXqSg5PzJAJjFIYFWeaKYYEZqxfkedHi9SjfmZ8hmeqaoAcq3ruD776MB/++iOsHc0tcq96aF7G4kKdip3+/emEXmxTK1oJwNcDo8B1wO8DVwDvaLSRu5eA881sDXC7mb3U3b/fakPN7FrgWoDNW7YwnMssGtwqAaUqBdPMeGZ8mtUjuXnBZmwow8HxqDd89UhuXkZPNmM8e2KazWtHKwVZyo+dMlUIyQbzC49nAmOqEPLM+DRrqtoEkA1yHByfZuPK4brPb1g5RBKePr74MRvdX50uhmRqgn1g0b/yp64a5uCJaVYP5yrPOdHcfs+MT5HPBpX02er/jUKPZoOuvV1q8X6hfr2NRtsmZbFxzg4cnZplzWiu8oc6Wu6MTxf59NWv5Mo//lalels5iyyMU2NHcgGBGcXQK8G7rBQ6z56Y5dkTsycfuMbK4ey8xJd1Y3n2HRpnbCiLu5MJgriIvvH08SkcllwPpR313tu02tSKVqqh3QcQXwVf5+7jrRzI3Z8zs38AXgdUB+AngS3AgfgWxGqizrja7W8CbgLYtm2bNxpLupCt68c4OD5dqU4FMDlb5IXrxwAWeK7ElnVjiQ4xGstHf5Wra7CEHi3fsnb0pDZNFUpsXhv1+Dd6PgntHLP8WquDt7uxYijD2FCWF65b+P3Zun5F3f2vGIqqjNVW+BrLZzht9XBlvyP5oJL6OjlbYtPq5uttdFq5JsNCyxvVFhnJZZgplir/ZUVX7R7dK964ct625aF6K4dz/IdLt1am6Sp3MFaPBKn+ozM+XWR8usiPajoVT8zU1GVmrmj+8akC+WwQTT0VX72vG8vz7IkZ1o7mEynU1OhcLbVGS7e0MgpiG1FH3Mr452PAf3D3PXW22QAU4uA7AryWqJOt2k6iK+nvEE32uave/d92vOuyM/jAzoeYnC3Oq8/6rsuigRz1nkvKNZeezg279lEMw8ovZejR8vM2r6nbpkavJwntHLPea21n3+X9ltznis1g/NrPnMFoPstvXP4iPrDzIWaLYWW/YFz/mjN54MBzfPzvfwg1bbr6kheybixP6HNFaoqhUyw5xbD9eQjq1WS48qdOq1tD4q0Xbl60Rki536CybTHEgXdespVXbq3/b/dUPKb6cNyBGHUkzgXpA0eneOb49Lw/HA7MlkLKA0KmampYPzsxy1s/dQ8GrKm5/bHYCJBWMhUb1dtYao2Wbmm1IPt73P0f458vBf7fenWCzew84BYgQzRi4ovuvsPMdgC73X1nPFTts8AriKa8v8rdH6vXlm3btvnu3bubanet8gwFB45OsrlmhoJ6zyXpxjse5ea79zMxW2Isn+GaS0/nuitf0lSb0mhzO8es91rb2Xc7+220ba1yjeFojru5oFyqfO9NFYCpV5OhUQ2JZkbOdLr+RHnfX/juj/nJsSnWjua5+Iz1nLJyiCOTszz8k+M8/PR49N8IRujzb4E0aySXmav1sUj9j3L508Cs7utN8lw0qyO1IBYqtmNme92962X02wnAIt0QxvdfS6FTcqdUcmZLIcUwpFDszFV0r3N3JmZK8RV1/dTy8apMxWZlAmPt6NyVc3XSS/m+db1OxW7p1CiIb5nZp4AvEP3n8TbgTjO7AMDd97bdUpEBEQRGvs49T/coIJc7ykrxlXM0B144EAXSzYwVw1lWDGcr/SyLmS2GHJmM70tX5lCcOSlgH52YK9TUcqdinZlfykF8bKi7s7+0EoBfHj9+sGb5K4gC8hUdaZHIMmBmDGUXv9dZKl89h9HV8kwxZDb+qlcruF/lswGnrRrmtCYyFY9NFRac9aUSpCfrdCouMoSvuh3R1XPupKF55Vsg68fyrOlQp2IroyB+tu2jiUhTMvHEofFPUc93rFCaC8aFUkghdAoDGi+Et7MAABTMSURBVJhrBRbVh147mudFDdadml389kf1FXV1puJsMeTp49M8fXwaWHygV2Dl8qdDlWAdPdaMqR7Ls7JqaGWtVkZBnAr8IfA8d3+9mZ0DXOzuf9bsPnpdUlOIy5xG5zip96DefttpU1Kvp952uUxALhMwVjPUu3zfuRiG8USkUYCeKaQfnNNICR7JZ9icH204RLJYCjk6WahcOVff/jgajwYpB+9Caa5QU7RNAU4ezDLPWD7DQztet+BzrXTCfY1oGNp/dfeXx2N2v1dOS+6mJDrhkppCXOY0OsdJvQf19gssuU3tbFvv9SRxHmaKJaZnQ6YKJaYLpa4G5DRS5pPg7pyYKc6/Lx3fAjk6OX9SgdpOxcf/nze03Ql3irt/0cx+N25M0cySTRfqoqSmEJc5jc5xUu9Bvf0CS25TO9vWez1JnIehbIahbIbV5HCPUptnCiEzpSi4FxPs+FtqinmvMTNWDudYOZxjazOdivGY6snZxUe8tBKAJ8xsPfHsGGZ2EfPTzfvaE0cnWTMy/17NSC7DgaOdLZiynDU6x0m9B/X267DkNrWz7VLb2wlmxnAuw3AuA1Slfsfjm8u3LmaLIbOl6HZGO7lR9dKFB1U+G3Da6mFOWz3cmXvAwG8TZa29yMz+CdhAlLk2ENJI611u0kqtbrTfdtqUxOtJ67NoZuSzdtKY2XJgnimWmC6EzBRLLQXlRunCy1kro5NfBLweuAT4O+CHDNC09u+67AwKJWdytoh79NiNVOTlpNE5Tuo9qLffdtqU1Ovptc9iFJiDckIBm9eOsnX9KM9fO8KGlUOsHskxnMssWuryqlduoRhGRZOc6LHXUoLT0lIqsrufF6cg/z7RXHEfcPefTrKBC0kqEy6tVOTlJK3U6nZS0JPatp3z1KvKQ+Nmi9HY5ZliiVLoPZESnJaOpiKb2YeBB939LxZKT+4GpSKL9I9CaS6RZKZY6olhcd3UqVTkJ+NU5NcCH4nnctOkVSJSV3ncMlXjlssdfDOFEtNxcE6oCGJPayUAv5Wolu9H4/KSm4D/lEyzRGSQ5bMB+WzAiqEoBJVrY1SGxxVLzBYHv2BRK6nIk8CXq35+CngqiUaJyPJSro0xlM1U5lyvHa8c3V9ub0hcrxmYUQwiMlgWGq9cvlIud/JNF/r7SlkBWLqqUW2EZorTd7pORLPF3JdSCyKN19OPNU2abXP1lXK5QFEYOtNx5950TSdfr09Ln/nQhz6UdhtadtNNN33o2muvTbsZ0qJyjYPpQomVQ1mOTRX4+0cOcvr6MbaeMsaNdzwaTS0UOpkACiXnnv1HMHemZkt1t12qesf86TPW123z489O9NzraXSOe1G7bTYzcpmAkXyGlcM51ozmGRvKct/+I3z0m48yU4z++I1PF/nOY4fZsiYaw9wtQ9kMY0PZ/3uh5zSKQbqmusaBWfSYy1ilrsLNd+8nMMgGAYEF8WO0vNG2S1XvmI3a3IuvJ6n9JimJNuezAZ+550cM5wJWj+QZymZYNZJjKBvwpT0HolEZPUC3IKRrGtU4mJgtUTtzTGDR8qTqI9Q7ZqM2N6oFkcbr6ceaJt04F+UZpFcMZTk4Ps2WdaOEoVeSRcqdfd2eKqo3/gzIsrBl7ei8WQpgfo2DsXzmpKnaw3h6+UbbLlW9YzZqcy++nqT2m6S0zkUQGCP5DGtG85y6apgXrB/lBetGOXXVMGtGo9mZF0uv7hQFYOmaRjUOrrn0dEKHYhgSehg/RsuTqo9Q75iN2tyLr6fX6kg0o5fORTYTMDYUzR+3afUIW08ZY/PaUTasHGLVSK7jk3uqE066ZuspY5y+foxHnh7n0PgMm1aP8J/+zVmV3u6fPmM95s6DTx5jpuiM5jP8xv/1Iq678iUNt12qesds1OZefD1J7TdJvX4uMkE08mI0n2XVSI7VIzlG8llymQAzCEOoNzK5Xidc07UgeolqQYhIL6mU6iyU4hk/5u4ld6oWhIiILKCSxRd3+hVLYSVhpN7syQrAIiIdls0EZDMBo/n666kTTkQkJboCXsbSSFlt55i/9Klv8539Rys/X3z6Wr7wrksSP247++3HtGDpHnXCLVNJTQGf1DFrg29ZM0E4jenu25mWXgbSgjeCdQtimUojZbWdYy4UfOst79Rx29lvP6YFS3cpAC9TTxydnDdLLSSfsprGMZM8bqP9pvV6pX8oAC9TaaSsppUmm1aqaz+mBUt3KQAvU2mkrLZzzItPX9vS8k4dt5399mNasHSXOuGWsTSmPm/nmJ0YBdHN6e6TPK70nfampe8lCsAi0mc0CkJEpJcoAIuIpEQBWEQkJQrAIiIpUS0I6bh26h+0MwV8Gu2V3tbr761GQUhHtVP/oN62QCr1HKR/9dh7q1EQkrx26h+0MwV8Gu2V3tYP760CsHRUO/UP6m2bVj0H6V/98N4qAEtHtVP/oJ0p4NNor/S2fnhvFYClo9qpf9DOFPBptFd6Wz+8t+qEk45rp/5BvW3Tqucg/auH3lvVghARSYlGQYiI9BIFYBGRlCgAi4ikJNFUZDPbAnwGOBVw4CZ3v6FmncuB/wPsjxd92d13JNmufpJUWm+S2kkn7vXU0Vo33vEoN9+9n4nZEmP5DNdcejrXXfmSxI/bb+dJFpZoJ5yZbQI2ufteM1sJ7AF+wd1/ULXO5cD73f2Nze53uXTCJZXWm+QvajvpxD2WOtrQjXc8yg279hEYBAahR1/XX/HiRINwv50nAdLohHP3p9x9b/z9OPAw8PwkjzlIkkrrTavNgzaN+8137ycwyAYBgQXxY7Q8Sf12nmRxXbsHbGZbgVcA9y7w9MVm9s9m9jUzO3eR7a81s91mtvvQoUMJtrR3JJXWm6R20on7IXW02sRsiaDmuiawaHmS+u08yeK6EoDNbAXwV8B73f14zdN7gRe6+8uBPwH+eqF9uPtN7r7N3bdt2LAh2Qb3iKTSepPUTjpxP6SOVhvLZwhr7uCFHi1PUr+dJ1lc4gHYzHJEwffz7v7l2ufd/bi7n4i//yqQM7NTkm5XP0gqrTetNg/aNO7XXHo6oUMxDAk9jB+j5Unqt/Mki0u6E86AW4Aj7v7eRdY5DXjG3d3MXgXcRnRFvGjDlksnHCSX1pukdtKJeyh1tClpj4Lol/MkKaQim9mlwD8CDwJhvPj3gBcAuPsnzew3gXcDRWAK+G13/3a9/S6nACwiA2HBAJzoOGB3v3uxA1et8wngE0m2Q0SkFykTTkQkJQrAIiIpUQAWEUmJpqXvcf2Y85/WyACRfqMr4B5Wzvk/OD7NmpEcB8en+cDOh7jzkYNpN21R5foIU4US2SBKELhh1z5uvOPRtJsm0nMUgHtYP+b8p1UfQaQfKQD3sH7M+U+rPoJIP1IA7mH9mPOfVn0EkX6kANzD+jHnP636CCL9SKMgetjlZ29kB/RVzn95tINGQYg0pmnpRUSSp2npRUR6iQKwiEhKFIBFRFKiTrgW9GJasNqUruX0WqXzdAXcpF5MC1ab0rWcXqskQwG4Sb2YFqw2pWs5vVZJhgJwk3oxLVhtStdyeq2SDAXgJvViWrDalK7l9FolGQrATerFtGC1KV3L6bVKMpQJ14JenApcbUrXcnqt0pbuT0ufFKUii0ifUSqyiEgvUQAWEUmJArCISEoUgEVEUqJaELIs3HjHo0suEq96D5IUXQHLwLvxjke5Ydc+pgolskGULHHDrn3ceMejDbdVvQdJkgKwDLyb795PYJANAgIL4sdoeSOq9yBJUgCWgTcxWyKoGYUZWLS8EdV7kCQpAMvAG8tnCGvyjUKPljeieg+SJAVgGXjXXHo6oUMxDAk9jB+j5Y2o3oMkSaMgZOCVRzssZRTE5WdvZAeo3oMkQrUgRESSp1oQIiK9RAFYRCQlCsAiIilRABYRSYkCsIhIShSARURSogAsIpISBWARkZQoAIuIpEQBWEQkJQrAIiIpUQAWEUmJArCISEoUgEVEUqIALCKSkkQLspvZFuAzwKmAAze5+w016xhwA/BzwCRwtbvvTbJdg0RTpov0r6SvgIvAf3T3c4CLgPeY2Tk167weODP+uhb404TbNDA0ZbpIf0s0ALv7U+WrWXcfBx4Gnl+z2s8Dn/HIPcAaM9uUZLsGhaZMF+lvXbsHbGZbgVcA99Y89XzgiaqfD3BykMbMrjWz3Wa2+9ChQ0k1s69oynSR/taVAGxmK4C/At7r7seXsg93v8ndt7n7tg0bNnS2gX1KU6aL9LfEA7CZ5YiC7+fd/csLrPIksKXq583xMmlAU6aL9LdEA3A8wuHPgIfd/Y8XWW0n8CsWuQg45u5PJdmuQXH52RvZsf1cNq4c5thUgY0rh9mx/VyNghDpE4kOQwNeDbwdeNDM7o+X/R7wAgB3/yTwVaIhaPuIhqG9M+E2DZTLz96ogCvSpxINwO5+N2AN1nHgPUm2Q0SkFykTTkQkJQrAIiIpUQAWEUmJArCISEoUgEVEUqIALCKSEgVgEZGUKACLiKTEojyI/mJmh4AfpdiEU4BnUzz+QtSm5qhNzVGbmtNsm55199fVLuzLAJw2M9vt7tvSbkc1tak5alNz1KbmtNsm3YIQEUmJArCISEoUgJfmprQbsAC1qTlqU3PUpua01SbdAxYRSYmugEVEUqIALCKSEgXgOswsY2bfM7O/WeC5q83skJndH39d06U2PW5mD8bH3L3A82ZmN5rZPjN7wMwu6IE2XW5mx6rO1Qe60KY1ZnabmT1iZg+b2cU1z6dxnhq1qavnyczOqjrW/WZ23MzeW7NOV89Tk21K4/P0PjN7yMy+b2ZfMLPhmueHzOwv4/N0bzwLfGPurq9FvoDfBv4C+JsFnrsa+EQKbXocOKXO8z8HfI1oJpKLgHt7oE2XL3QOE27TLcA18fd5YE0PnKdGber6eao6dgZ4Gnhh2uepiTZ19TwBzwf2AyPxz18Erq5Z5zeAT8bfXwX8ZTP71hXwIsxsM/AG4Oa029Kinwc+45F7gDVmtintRnWTma0GLiOaEBZ3n3X352pW6+p5arJNaXoN8K/uXpthmubnabE2pSELjJhZFhgFflLz/M8T/YEFuA14TTwpcV0KwIv7OPA7QFhnnTfH/5bdZmZbutQuB75hZnvM7NoFnn8+8ETVzwfiZWm2CeBiM/tnM/uamZ2bcHtOBw4Bn45vId1sZmM163T7PDXTJujueap2FfCFBZan8XkqW6xN0MXz5O5PAh8Ffgw8RTRz+zdqVqucJ3cvAseA9Y32rQC8ADN7I3DQ3ffUWe0rwFZ3Pw/4JnN//ZJ2qbtfALweeI+ZXdal49bTqE17if6NfDnwJ8BfJ9yeLHAB8Kfu/gpgAvgvCR+zkWba1O3zBICZ5YHtwJe6cbxmNGhTV8+Tma0lusI9HXgeMGZmv9yJfSsAL+zVwHYzexy4FbjCzD5XvYK7H3b3mfjHm4ELu9Gw+K8x7n4QuB14Vc0qTwLVV+Ob42Wptcndj7v7ifj7rwI5MzslwSYdAA64+73xz7cRBb9q3T5PDduUwnkqez2w192fWeC5rn+eGrUphfN0JbDf3Q+5ewH4MnBJzTqV8xTfplgNHG60YwXgBbj777r7ZnffSvRv0C53n/cXr+Y+2Hbg4aTbZWZjZray/D3wb4Dv16y2E/iVuPf6IqJ/l55Ks01mdlr5fpiZvYroc9fww7lU7v408ISZnRUveg3wg5rVunqemmlTt89TlV9i8X/1u3qemmlTCufpx8BFZjYaH/c1nPz7vhN4R/z9W4hiRsMst2xHmzngzGwHsNvddwLXmdl2oAgcIRoVkbRTgdvjz14W+At3/7qZ/TqAu38S+CpRz/U+YBJ4Zw+06S3Au82sCEwBVzXz4WzTbwGfj/+VfQx4Z8rnqZk2df08xX80Xwu8q2pZquepiTZ19Ty5+71mdhvRrY8i8D3gppp48GfAZ81sH1E8uKqZfSsVWUQkJboFISKSEgVgEZGUKACLiKREAVhEJCUKwCIiKVEAFhFJiQKw9L24POFJJUOrnr/azD6RwHGvNrPnVf38eJcy12RAKACLLN3VRLUBRJZEAVi6Ik5Z/tu4gtX3zextZnahmX0rrqL2d+X0bjO708xusKjY9vfjdFPM7FVm9p24mti3q9J6W2nHBjP7KzO7L/56dbz8Q2b25/GxHzOz66q2+W9m9i9mdrdFxbjfb2ZvAbYRZbbdb2Yj8eq/ZWZ7LSpQf3addqwws0/H6z1gZm+Ol58wsz+yqPj3HfFrLrdpe6uvV3qbArB0y+uAn7j7y939pcDXiSpZvcXdLwT+HPjvVeuPuvv5RIWu/zxe9gjwM3E1sQ8Af7iEdtwAfMzdXwm8mfn1ns8G/i1RMaEPmlnOzMrrvZyoQMw2AHe/DdgN/Ht3P9/dp+J9PBtXhvtT4P112vHfiOoqvCyuqLcrXj5GVEfgXGAc+AOitNw3ATuW8Hqlh6kWhHTLg8D/NLOPAH8DHAVeCnwzriORIaq1WvYFAHe/y8xWmdkaYCVwi5mdSVSDOLeEdlwJnGNztbJXmdmK+Pu/jSvczZjZQaI6F68G/o+7TwPTZvaVBvv/cvy4B/jFBu2o1Atw96Pxt7NEf5wgOmcz7l4wsweBrY1enPQXBWDpCnd/1KL5xH6O6KpuF/CQu1+82CYL/Pz7wD+4+5ssmnPrziU0JQAuigNqRRyQZ6oWlVja70d5H0vdvlBVWCYs78/dQ4vKHMoA0S0I6Yp4tMCku38O+CPgp4ENFk9MGf+7Xz2zwdvi5ZcS/at+jKjGarkW7dVLbMo3iKqSldt1foP1/wn4d2Y2HF8pv7HquXGiq/Kl+Cbwnqp2rF3ifqSPKQBLt7wM+K6Z3Q98kOge7luAj5jZPwP3M7/I9bSZfQ/4JPCr8bL/AXw4Xr7Uq8HrgG1xx9cPgF+vt7K730dU6/UBoskpHySabgbgfwOfrOmEa9YfAGvjTsZ/Bn62xe1lAKgcpfQcM7sTeL+7nzTFfRrMbIW7nzCzUeAu4Fp335t2u6T/6Z6SSGM3mdk5wDBwi4KvdIqugGVgmNk7getrFv+Tu79nofW7oRfbJL1DAVhEJCXqhBMRSYkCsIhIShSARURSogAsIpKS/x+i5U0dZ+va6QAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 360x360 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "sns.lmplot(x=\"sepal_length_cm\", y=\"sepal_width_cm\", data=df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In `sklearn`, we can represent the model (in this case, a linear regression on selected features) as a pipeline:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "simple_model = Pipeline([\n",
+    "    (\"features\", PandasValueSelector(\"sepal_length_cm\")),\n",
+    "    (\"lr\", LinearRegression()),\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Pipeline(memory=None,\n",
+       "     steps=[('features', PandasValueSelector(columns='sepal_length_cm')), ('lr', LinearRegression(copy_X=True, fit_intercept=True, n_jobs=None,\n",
+       "         normalize=False))])"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "simple_model.fit(df, df[\"sepal_width_cm\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MSE = 0.18610437589381357, MAE = 0.33122352979559877\n"
+     ]
+    }
+   ],
+   "source": [
+    "y_pred, y = simple_model.predict(df), df[\"sepal_width_cm\"]\n",
+    "print(f\"MSE = {mse(y, y_pred)}, MAE = {mae(y, y_pred)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Intercept: 3.42, slope: -0.06\n"
+     ]
+    }
+   ],
+   "source": [
+    "lr = simple_model.named_steps['lr']\n",
+    "print(f\"Intercept: {lr.intercept_:.2f}, slope: {lr.coef_[0]:.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fit a model per category"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can improve the regression model signiifcantly  by adding the categorical feature `species` - we could try on-hot encoding, embeddings, etc. However, a common approach would be to fit a separate regression model *per category*:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<seaborn.axisgrid.FacetGrid at 0x7f600bee2860>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAbIAAAFgCAYAAADehfw4AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAgAElEQVR4nOzdeXzdZZX48c+5W+69WZqka5ruha6CQMsimyCgIHWZ0R/CaEeccdzF0dFREatTlHFXcJsKowguKI7O1ILsW5GttAile+lCGrK12W5y9+/3+f3x/SZN2iTNTe6W5Lxfr77S3Nz7/T5tk577PM95zhFjDEoppdRY5Sn0AJRSSqnR0ECmlFJqTNNAppRSakzTQKaUUmpM00CmlFJqTPMVegB9XX755ea+++4r9DCUUiobpNADmCiKakZ2+PDhQg9BKaXUGFNUgUwppZTKlAYypZRSY5oGMqWUUmOaBjKllFJjmgYypZRSY5oGMqWUUmOaBjKllFJjmgYypZRSY5oGMqWUUmOaBjKllFJjmgYypZRSY5oGMqWUUmOaBjKl1ISQSFvYtin0MFQOaCBTSo178ZRFY0ccDWPjU1H1I1NKqWzrCWK20TA2XmkgU0qNW7GkRVOnBrHxTgOZUmpciibTNHUmMBrExj0NZEqpcac7kaY5okFsotBAppQaV7oSaVo0iE0oGsiUUuNGJJ6iJZIo9DBUnmkgU0qNCx2xFEe6NIhNRBrIlFJjXkc0xZFuDWITlQYypdSY1h5N0tqdLPQwVAFpIFNKjVmt3UnaoxrEJjoNZEqpMelIV4KOWKrQw1BFQAOZUmrMaYkkiMQ1iCmHBjKl1JjSHInTFU8XehiqiGggU0qNCcYYWiIJuhIaxFR/GsiUUkXPGENTZ4JoUoOYOp4GMqVUUTPG0NgZJ5a0Cj0UVaQ0kCmlipZtO0EsntIgpgangUwpVZQs29DQESOZtgs9FFXkNJAppYpO2rJp6IiTsjSIqRPTQKaUKiopy6ZRg5jKgAYypVTRSKadIJa2NYip4dNAppQqCom0RWNHHMvWhpgqMxrIlFIFF085QczWrs5qBDSQKaUKKpa0aOrUIKZGTgOZUqpguhNpmiMJjAYxNQoayJRSBdGVSNOiQUxlgQYypVTedcZTHI4kCj0MNU5oIFNK5VVHNMWRbg1iKns0kCml8qatO0lbNFnoYahxRgOZUiovjnQl6IhpV2eVfZ5c30BEKkXkDyKyU0R2iMgbcn1PpVRxaYloEFO5k48Z2c3AfcaYd4tIAAjn4Z5KqSKgXZ1VPuQ0kInIJOBC4FoAY0wS0AVypSYA7eqs8iXXS4vzgRbgFyLygojcJiKlfZ8gIh8SkedF5PmWlpYcD0cplQ89DTE1iKl8yHUg8wFnAD81xpwOdANf6PsEY8zPjDErjTErp06dmuPhKKVyzbYNDZ1xYknt6qzyI9eB7BBwyBjzrPv5H3ACm1JqHLJsw2sdMRIpDWIqf3IayIwxjUCdiCx2H7oE2J7LeyqlCiNt2bzWHiOZ1l5iKr/ykbX4SeDXbsbiPuADebinUiqPxkpX50TKIlyix2fHm5z/ixpj/gaszPV9lFKFkUhbNHUkirqrczJts+6Jfext7uIPH30DJT5voYeksijnB6KVUuNXT0PMYg5i9e0xrrvrBf70Qj1b6zv47bOvFnpIKst0jq2UGpGx0NX5sV0tfPeBXXQnLQS47pKTWf2GeYUelsoyDWRKqYxFk2maOou3l1gybfOTx15h/YuvAVBdGuBLb13CO0+fhdcjBR6dyjYNZEqpjBR7V+e61ihrN2znlZZuAFbMreL6ty6hKhwo8MhUrmggU0oNWySeoqWIG2I+vKOJ7z24h1jKwiNw7bnz+Iez5+ARnYWNZxrIlFLD0hFLcaSrOINYPGXxo0f2cu/LjQBMKQtww5VLOXVWZYFHpvJBA5lS6oTao0lau4uz3vfBI92s3bCD/YedpcSz5lfzxcuXMCnsL/DIVL5oIFNKDam1O0l7kXZ1vn9bIzc/tId42sbrEf75/PlctXKWLiVOMBrIlFKDOtyVoLMIG2LGUhY3P7SHB7Y3ATCtvIQvr1rK8pmTCjwyVQgayJRSA2qOxOmKF18bln0tXdy4YQcHW6MAnLdwMp97y2IqQrqUOFFpIFNK9VOsXZ2NMdy7tZEfPrqXZNrG5xE+dOEC3nVGLaJLiROaBjKlVK9i7eocTab53oN7eGRnMwA1k4J8edVSlsyoKPDIVDHQQKaUAo52dY4XWS+xvc1drN2wnUNtMQAuPHkKn33zYsqC+t+Xcuh3glIKyw1ixdQQ0xjD+hcb+Mlje0lZBr9X+MgbF/LO02bqUqLqRwOZUhOcZRsaOoqrIWZXIs13H9jN47tbAJhZGWTNqmUsml5e4JGpYqSBTKkJLG3ZNBRZQ8xdjRHWbthOQ0ccgIsXT+Uzly2iVBtiqkHod4ZSE1SxdXU2xvDHF+pZ9/g+0rYh4PPwiYsXcuUpNbqUqIakgUypCSiZtouqIWYknuJb9+/ir3uPADC7KsSaty1j4dSyAo9MjQUayJSaYBJppyGmZRdHG5YdDZ2s3bCdpk6nIPGlS6fx6UsXEQp4CzwyNVZoIFNqAimmrs62Mfxh8yFu3bgfyzaU+Dxcd8nJXL58ui4lqoxoIFNqgoglLZo6iyOIdcRSfPO+nTyzrxWAuZPDrFm1jPlTSgs8MjUWaSBTagIopq7OL9d3cOOGHbS4vc2ueN0MPvmmkwj6dSlRjYwGMqXGua5EmpYiCGK2Mdz1XB0//+t+bANBv4dPX7qIy5ZNL+i41NingUypcawznuJwpPBdnduiSb7xl51sOtAGwIKppay5chlzJocLPDI1HmggU2qc6oimONJd+CD2Yl07X7tnB0fcDtOrTq3h4xctpESXElWWaCBTahxq607SVuCuzpZt+PWzB7nj6YPYBsIBL5+5bBFvWjKtoONS448GMqXGmSNdCToK3NW5tTvJTffuYMur7QCcPK2MNauWUVsVKui41PikgUypcaQlkiASL2wQ23Kwja/fu4O2qDOOd542k4+8cSEBn6eg41LjlwYypcaBYujqbNmGO54+wK+eeRUDlJZ4+dxbFnPhyVMLNiY1MWggU2qMM8bQHEnQXcAgdrgrwdfu2cFLhzoAWDyjnDWrllIzSZcSVe5pIFNqDDPGaYgZSxauIeZz+1v5xl920u7uy/2/FbP44AXz8Xt1KVHlhwYypcYo2+3qHC9QV+e0ZfOLpw7w2+fqACgP+vj85Ys5d+GUgoxHTVwayJQagyw3iCUKFMSaO+N87Z4dvPxaJwDLair48qqlTK8IFmQ8amLTQKbUGFPors5Pv3KEb963k864syd39Zmz+afz5uHTpURVIBrIlBpDCtnVOWXZ3LZxP3dvPgRARdDHF65YwjkLJud9LEr1pYFMqTGikF2dGzvi3HjPdnY0RAA4pbaCG65cxtTykryPRaljaSBTagyIp5xeYoXo6vzknsN86/5ddCXSCPAPZ8/h2nPn4fVo80tVHDSQKVXkCtXVOZm2+dkT+/jjC/UAVIX9fPGKJaycV53XcSh1IhrIlCpisaRFY2c8773E6ttj3LhhO7ubugA4bXYlX3rrEiaX6VKiKj4ayJQqUoXq6vz47ha+c/8uupMWAqx+w1xWnzNXlxJV0dJAplQRisRTHO5K5jWIJdM2P3nsFda/+BoA1aUBrn/rEs6YU5W3MSg1EhrIlCoyHbEUR7ry2xCzrjXKjRt2sLfFWUpcMbeKL16xhOrSQF7HkSseESaF/OikcnzSQKZUEWmPJmntzm9DzId3NPG9B/cQS1l4BD5w3jyuOWsOHhn7/+uLCOVBH1XhgC6NjmMayJQqEq3dSdrz2NU5nrL40aN7uXdrIwBTygLccOVSTp1Vmbcx5FJZiY+q0oAWL54ANJApVQQOdyXozGNX54NHulm7YQf7D3cDcNb8ar54+RImhf15G0OuhAJeqsIBgn5voYei8kQDmVIF1hyJ0xXPXy+xB7Y18oOH9hBP23gEPnjBAq5aOWvMLyUGfB6qSwOEA/rf2kSj/+JKFUi+uzrHUha3PLyH+7c1ATCtvIQvr1rK8pmT8nL/XPF7PVSG/ZQHx/5sUo2MBjKlCsAYQ1NngmgyP0Fs/+Fu1v55OwdbowCcu3Ay//6WxVSExu5//l6PUBkKUBHyIWN8NqlGRwOZUnlm24amSH66OhtjuHdrIz98dC/JtI3PI/zLhQt49xm1Y/Y/f3FT6StDfjyaiajQQKZUXuWzIWY0meb7D+7h4Z3NANRMCvLlVUtZMqMi5/fOlfKgn6qwX3ufqX5yHshE5AAQASwgbYxZmet7KlWMLNvQ0BEjmc59G5a9zV2s3bCdQ20xAC48eQqfffNiyoJj871raYlzFizg0wCmjpev7+qLjTGH83QvpYpOvro6G2P480sN/PjRvaQsg98rfPSNC3nHaTPH5FJi0O+lulRT6dXQxubbM6XGkHw1xOxKpPnuA7t5fHcLADMrg6xZtYxF08tzet9c0FR6lYl8fJcY4AERMcA6Y8zP+n5RRD4EfAhgzpw5eRiOUvmTSFs0dSRyHsR2NUZYu2E7DR1xAC5ePJXPXLaI0pKxFQj8Xg9VpQHKxti4VWFJrqtri0itMaZeRKYBDwKfNMY8MdBzV65caZ5//vmcjkepfMlHV2djDH98oZ51j+8jbRsCPg+fuHghV55SM6aWEsfpWbCx8w8wxuX8bY8xpt792CwifwLOAgYMZEqNF/no6hyJp/jW/bv4694jAMyuCrHmbctYOLUsZ/fMNp/Hw6Swn4qgngVTI5fTQCYipYDHGBNxf/9mYG0u76lUoUWTaZo6c9sQc0dDJ2s3bKep02n3ctmy6fzrJScTCoyNpAivxzkLNink1wCmRi3XM7LpwJ/cb1Qf8BtjzH05vqdSBdOVSNOSw67OtjH8YfMhbt24H8s2lPg8XHfJyVy+fPqYCAg9fcEm6WFmlUU5DWTGmH3A63N5D6WKRSSeoiWSu4aYHbEU37xvJ8/sawVg7uQwa1YtY/6U0pzdM1tEhIqgj0rtC6ZyQFODlMqCXHd1frm+gxs37KDFvccVr5vBJ990UtGfrxIRpy+YVuNQOaSBTKlRymVXZ9sY7nqujp//dT+2gaDfw6cvXcRly6bn5H7ZVOZ2ZtbGlirXNJApNQq57OrcHk3yjb/s5LkDbQAsmFrKmlXLmFMdzsn9siUc8FFV6qfEV9yzRTV+DDuQiUgl8I/AvL6vM8Zcl/1hKVX8ctnV+cW6dr527w6OdDlB8m2n1vCxixZSUsRLiQGfh8mlJWMmc1KNH5nMyO4FngG2ArmveqpUEWuJJIjEsx/ELNvwm2df5ZdPH8A2EA54+bfLFnHxkmlZv1e2+DweqkrH3WFmNYZkEsiCxpjP5GwkSo0RzZE4XfHsN8Rs7U5y07072PJqOwAnTSvjK6uWUVsVyvq9ssEjQmVYz4KpwsskkN0pIv8CbAB607OMMa1ZH5VSRSpXQWzLwTa+fu8O2qLOLO/vTq/lwxcuKNq2JeVBP9WlmkqvikMmgSwJfBv4Ek4hYNyPC7I9KKWKUS6CmGUb7nj6AL965lUMUFri5XNvXsyFi6Zm9T7ZEg74qC7VvmCquGQSyP4NOEn7iqmJxhhDcyRBdyK7QawlkuDr9+7gpUMdACyeUc6aVUupmVR8S4klfi/V4YAmcqiilEkg2wtEczUQpYqRMYamzgTRZHaD2HP7W/nPv+ykw816fPeKWv7lggVFd+ZK26qosSCT785u4G8i8ij998g0/V6NS7ZtaIrEiSWtrF0zbdn84qkD/Pa5OgDKgz7+/S2LOe+kKVm7Rzb4PB4qS/2Ul2hVelX8Mglk/+v+Umrcs21DQ2ecRCp7Qay5M87X7tnBy691ArCspoIvr1rK9Ipg1u4xWl6PUBkOaFsVNaZkEsj+AMSNMRaAiHiBkpyMSqkCsmxDQ0eMZDp7xyWfeuUw37pvF51ussjVZ87mn86bVzT1B3vaqlQEtSq9GnsyCWQPA5cCXe7nIeAB4NxsD0qpQklbNg0dcVJWdoJYyrK5beN+7t58CICKoI8vXLGEcxZMzsr1R8sjQkXIT6W2VVFjWKYHonuCGMaYLhEp7qJvSmUgZdk0ZjGINXTEuHHDDnY2RgA4pXYSN1y5lKnlhV/I0LYqajzJKNlDRM4wxmwBEJEVQCw3w1Iqv5JpJ4il7ewEsY17DvPt+3fRlUgjwD+cPYdrz51X8KChbVXUeJRJIPtX4G4ReQ0QYAbwnpyMSqk8SqQtGjviWPbouzon0zY/e2Iff3yhHoCqsJ8vXLGEM+dVj/rao6VtVdR4NexAZozZJCJLgMXuQ7uMMb1VU0XkMmPMg9keoFK5FE9ZNHVmJ4jVt8e4ccN2djc5K/Cnza7kS29dwuSywi4llpY4AUyrcajxKqNTjm7genmQL38T0ECmxox4ypmJ2Wb0QeyxXS1894FddCctBFj9hrmsPmduQZcSwwEflWF/0XeRVmq0snlcX3eM1ZgRS1o0dsYxowxiybTNTx57hfUvvgZAdWmAL711CafPqcrGMEdE+4KpiSabgWz0b2uVyoPuRJrmSGLUQayuNcraDdt5paUbgJVzq/jiW5dQFQ5kY5gZ66nGUaF9wdQEowXU1ITSlUjTkoUg9tCOJr734G7iKRuPwAfOm8c1Z83BU4BqGNoXTE102QxkB7J4LaWyLhJP0RJJnPiJQ4inLH706F7u3doIwJSyADdcuZRTZ1VmY4gZ0bNgSjkyCmQici4wr+/rjDF3uB//PqsjUyqLOmIpjnSNLogdPNLN2g072H/YWUo8e341X7h8CZPC+V/K00xEpY4adiATkTuBhcDfgJ5Kqga4IwfjUipr2qNJWruTo7rGA9sa+cFDe4innaXED16wgKtWzsr7UmLA52FKWYlmIirVRyYzspXAMjPazQWl8qitO0lbdORBLJayuOXhPdy/rQmAaeUlfHnVUpbPnJStIQ6Lz+OhqtRPuSZyKHWcTALZyzjVPBpyNBalsqq1O0n7KILY/sPdrP3zdg62Ov1kz104mX9/y2IqQvkLJh5xqtJXhjWRQ6nBnDCQicifcZYQy4HtIvIc/Rtrvj13w1MTyWM7m1n3xD7q2qLMrgrz4QsXcNGSaSO61pGuRG/35UwZY7h3ayM/fHQvybSNzyN86MIFvOuM2rwGk/KgX2siKjUMw5mRfSfno1AT3mM7m1mzfht+r1AZ8tMcibNm/TbWQsbB7HBXgs4RBrFoMs33HtzDIzubAaiZFOSGK5eytKZiRNcbiXDAR1WpnxKf7oMpNRwnDGTGmMcBROSbxpjP9/2aiHwTeDxHY1MTyLon9uH3CuGA8y0ZDviIJtOse2JfRoFsNEFsb3MXazds51Cb09ThwpOn8Nk3L6YsmJ/jliV+L9XhgFbkUEVDRO4F/sEY017osQwlk5/Qy4DPH/PYFQM8plTG6tqiVB6z9xTyeznUFh32NVoiCSLxzIOYMYb1Lzbwk8f2krIMfq/w0Tcu5B2nzczLUqLf66G6NEBpidYnUMXFGPPWQo9hOE64+C4iHxWRrcBiEXmpz6/9wEu5H6KaCGZXhYmlrH6PxVIWs6qG17u1ORIfURDrSqRZu2EHNz+8h5RlmFkZ5IfXnM47T8/9fpjP42FKeQmzq8MaxNSIiUipiNwjIi+KyMsi8h4ROSAi3xKRrSLynIic5D53qoj8j4hscn+d5z5eJiK/cJ//koi8y338gIhMcX//PvdafxORdSLidX/d7t53q4h8uhB/B8P56fkN8BfgP4Ev9Hk8Yoxpzcmo1ITz4QsXsGb9NqLJNCG/l1jKImUZPnzhgiFfZ4yhOZKgO5HO+J67GiOs3bCdho44ABcvnspnLluU86Di9QiVoQAVIZ9mIqpsuBx4zRhzJYCITMLpRtJhjDlFRP4R+AGwCrgZ+L4x5kkRmQPcDywFvtzzfPca/apei8hSnP6T5xljUiLyE+C9wDag1hjzOvd5+S9xw/ACmRfoBD5+7BdEpFqDmcqGi5ZMYy3OXtmhtiizhpG1aIyhqTNBNJlZEDPG8KcX6vmvx/eRtg0Bn4dPXLyQK0+pyWlgkZ5U+pAfj5aUUtmzFfium7OwwRiz0f0+/q379d8C33d/fymwrM/3eYWIlLmPX93zoDGm7Zh7XAKsADa5rw0BzcCfgQUi8kPgHuCB7P7Rhmc4gWwzTvq9AHOANvf3lcCrwPycjU5NKBctmTbsxA7bNjR2xokfsxx5IpF4im/dv4u/7j0CwKyqEF952zIWTi3LeLyZKAv6qA4HNJVeZZ0xZreInAG8FfiaiDzc86W+T3M/eoBzjDHxvtcYxhs4AX5pjPnicV8QeT3wFuAjwFXAP2X8hxilE/5UGWPmG2MWAA8BbzPGTDHGTMaZphYk+qqJLW3ZvNYRyziI7Wjo5EN3bu4NYpcunca6963IaRALB3zUVoWYVh7UIKZyQkRmAlFjzK+AbwNnuF96T5+PT7u/fwD4ZJ/Xnub+9kH6rLodu7QIPAy8W0SmuV+vFpG57v6ZxxjzP8ANfe6dV5lsBpxjjPmXnk+MMX8RkW/lYExKDSqZtmnqjJOy7GG/xjaGP2w+xK0b92PZhhKfh+suOZnLl0/P2VJi0O+lSlPpVX6cAnxbRGwgBXwU+ANQJSIv4RSwuMZ97nXAj93HfcATODOpr7mPv4xTS/c/gD/23MAYs11EbgAeEBGPe5+PAzHgF+5jAMfN2PJBhls6UUTuBzYCv3Ifei9woTHmLdkazMqVK83zzz+frcupcSaesmjqjGPZwy/32RFL8c37dvLMPmcrd+7kMGtWLWP+lNKcjDHgc1Lpe87DqQmtYBuhInIAWGmMOVyoMeRTJj9t1wBfAf7kfv4ER6O8Uv1ks9wUOBU3mjoza4j5cn0HN27YQYvbvuWK183gk286KSeV4/UsmFKFM+wZWT7ojGx86Ftuqm8q/dq3Lx9RMOuMpzjSlRx2ELON4a7n6vj5X/djGwj6PXz60kVctmx6xvc+Ea1Kr4agqal5MpyiwT8wxvxrn+LB/WjRYHWsbJWbgswr2LdFk3zjLzvZdMDJHl4wtZQ1Vy5jzuThHaweLj0LplTxGM46yJ3uRy0erIYlG+WmwKnW0RUf/hmxF+va+do9OzjiNtF826k1fOyihZRkcSlRz4IpVXyGUzR4c5/nPmWMieV2SGqsm10VpjkS75fwkEm5qUyrdVi24dfPHuSOpw9iGwgHvPzbZYu4eBR7cgPRtipKFadMfiL/EXhRRJ4RkW+LyNsGOGugFB++cAEpyxBNpjHG+TicclNwtFrHcINYa3eSz//PS9z+lBPETppWxrr3rchqECvxe5lZGWJqeYkGMaWK0LBTrIwx74few3fvBn4MzMzkGqq4ZSvTcCTlpsCp1tEUiRNLDu+g85aDbXz93h20RZ1iwe88bSYfeeNCAr7sBBtN5FATjYhcCzxgjHmt0GPJRCbnyN4HXIBz+O4w8CSw0Rjz9JAvzIBmLRZOtjMNM5VJySnLNtzx9AF+9cyrGKC0xMvn3ryYCxdNzcpYdB9MZUnG3zzzvnDP5cDncEr/7Qe+feAbV96X7YENRkQeAz5rjBlT/xFn8tb1B8BpwK3AdcaYb2UziKnC6ptpKOJ89HuFdU/sy/m9LdvQMMwg1hJJ8Nm7X+RON4gtnl7OuvetyFoQCwd81FaGqC4NaBBTeeUGsR8DNUCr+/HH7uMjNkiblxUi8riIbBaR+0WkRkTeDawEfu22agmJyCUi8oLbouXnIlLiXvMbIrLdbfnyHfext4nIs+7zHxKR7J93GUQmS4tTRGQ5cCHwdRE5GdhljFmds9GpvMlWpmGmUpZNY8fwSk49t7+V//zLTjrcDtDvXlHLv1ywAH8W9q38Xg+Ty7Qihyqoz+GUk+r5oYv2eXw0s7KB2rz8BXiHMaZFRN4DfN0Y808i8gncGZmIBIHbgUvcwsR3AB8VkTuBvwOWGGNMn9YtT+KUMjQi8kHg34F/G8W4h23YP7UiUoFT/X4uMA+YBAy/4J0qaqPNNByJ4ZacSls2P//rAe7aVAdAedDHv79lMeedNGXUY/B5PFSW+qnQfTBVePNxZmJ9RRl9h5F+bV5wOpi8DnjQPQPpBRoGeN1iYL8xZrf7+S9x6iv+CIgD/y0iG9xrAswCficiNUAAZ2k0LzJ5K/sk8DacrtDvMcYs7kkAUWPfaDINRyKesmjsOHEQa+6M8+nfv9gbxJbVVPCz1StGHcQ8IlSFA8yqCmkQU8ViP3DsO8cwowwIbiA6AyegfQ14F7DNGHOa++sUY8ybM7heGjgLpzDxKo7OFn8I/MhtzvlhIDiacWcik6XFU4f6uoj80BjzyUG+5gWeB+qNMasyG6LKh5FmGo5ETxCzT5Bo9PQrR/jmfTvpdA9FhwNe/B7h4OEo0ytG/jOi58FUkfo2zh4ZODOxMFDiPj5ibqZ5qzHmVyLSDnwMmCoibzDGPC0ifmCRMWYbEAHK3ZfuAuaJyEnGmL3AauBxtxFn2Bhzr4j8FejZSJ8E1Lu/z+skJ2u1FkVkizFmwF40IvIZnE3EiqECmWYtjn+xpLOcOFQQS1k2t23cz92bDwEgApNLA1SF/cRTNmnb8Kk3ncxZC6ozunc44KO6NJC19HylTqAoshZF5C04wbBvm5c0cAtO8PEBPzDG3Coi7wJuwmnP8gbgXJyqTj5gk/vaauD/cGZcAnzHGPNLEXkHTifqNuAR4ExjzEWjGfuw/4y5DmQiMgtnbfXrwGc0kE1c3Yk0zZGhK9g3dsS58Z7t7GiIAFAa8FIR8lNe0n/vbnJpCd97z+uHdd8Sv5dq7Q2m8k/TXvMkH29Nf4CTvTJgYoiIfEhEnheR51taWvIwHFUIkXiKps74kEHsyT2H+dCdm9nREEGA950zh9ISL2Ul/QNQ0O+hsfPEldL8Xg/TKoLUVoY0iCk1jmUz1/i4dx8isgpoNsZsFpGLBnqRMeZnwM/AmZFlcTyqSHTEUhxxe4INJJm2+dkT+/jjC87yelXYzxevWMLKedW8fKiTI90JQn0K/8ZTNjMqQoNerzohQdYAACAASURBVCeRQyvTKzUxZHNGdvMAj50HvN3tVnoX8CYR+dUAz1PjVHs0OWQQe609xnV3vdAbxE6bXcnPVq9g5Txn/+vqM2eTtg2xlIXB+Zi2DVefOfu4a/VU5JhdHWZS2K9BTKkJ4oR7ZIP1Iesx3H5k7ozss7pHNr7c8tBubntyP91Ji9KAlw+eP5/rLl0EnLiX2GO7WvjuA7voTlp4BFafM5f3nTMX7zEVNZ7b18pdm+po7IwxoyLE1WfOPi7Ro6zER1VpICuHo5XKEn0nlSfDWVrUPmRqQLc8tJubH9mLR8DncZIwbn5kLwDvPWdubwWOYyXTNj957BXWv+jUJa0uDXDDlUs5bXblgM8/a0H1oBmKQb+X6tIAwSz2HFNKjS3D6Uf2eDZuZIx5DHgsG9dSxeG2J/e7QcyZBXkE0rbNzzbuY9XrZw74mrrWKGs3bOeVlm4AVsyt4vq3LqEqHMjo3n6vh+rSAKUlWlJKqYkukxJVJwP/CSyjz4ltY0xuSj+ootedtOh7JMsYg2CIDtKG5eEdTXzvwT3EUs5S4gfOm8c1Z83Bk8FeltcjVIYDVAQ1kUOpQhGRtcATxpiHMnzdRZxgi2kkMnk7+wvgKzgH3i4GPkB+0vdVkSoNeHuDUs9eq23ol2EITiWPHz2yl3tfbgRgSpmzlHjqrIGXEgeirVXUhPDVSccdiOarHXlr49KXOO8UxRhz3NEpY8yaPI3B55bEGlImgShkjHkY5w920BjzVeDKkQ5QjX0fPH8+toGUZWEbm7RtYxu4asWs3uccPNLNx3/zQm8QO3t+NbeuXplRECsr8TGrSlurqHHOCWLHtXFxHx8xt+XKx/t8/lUR+ayIfE5ENrmtWP7D/do8EdnlVrp/GZgtIre77V+2isin3efd7rZ9QUTOFJGn3DYxz4lIuYgEReQX7mteEJGLBxhXtYj8r3v/Z0Tk1D7ju9Mtf3XncP6MmczIEiLiAfa4pf7rgbIMXq+KxKfv2sL6lxqxbIPXI7z91Bl8/+oBq4sN6bpLF2HZhv9+cj/RlEXI7+WqFbNYfe48AO7f1sjND+0hnrbxCHzwggVctXLWoEuJPdmJDZ0xaipCvPfsOax6/Uw9zDzObTy0kdu33U59Vz21ZbVcu/xaLph1QdZfMwbkqo3L73AKU/TUcbwK+CbO8aizcLIr14vIhcCrwMnA+40xz4jICqDWGPM6gD4tW3A/D7jXf48xZpPbJSUGfAowxphTRGQJ8ICILDpmXP8BvGCMeaeIvAm4A6fnJThbWOcbY05c+YDMAtmncIpYXgfcCLyJPBeGVKP36bu28Ke/He3YYNnG/XxLxsEsnrJ414rZvOP02n6Px1IWtzy8h/u3NQEwrbyEL69ayvKZkwa91nP7Wrn5kT34PEJF0E97LMktj+xhanlJXjpUq8LYeGgjNz17E36vn4pABS2xFm569iau5/pBA9NIXjNG5KSNizHmBRGZ5hYPnopTC/EU4M3AC+7TynAC2KvAQWPMM+7j+4AFIvJD4B7ggWMuvxhoMMZscu/VCSAi5+NUw8cYs1NEDgLHBrLzcSrxY4x5REQmu4EQYP1wgxhksLRojNlkjOkCOnE6RP99nz+sGiPWv+Qs8Ykc/dX38eGKJtM0dsRJ2/2Xz/cf7uZjv9rSG8TOXTiZn61eMWQQA7hrUx0+j1Ba4qPE56E86Cfg8+SlQ7UqnNu33Y7f6yfkCyEihHwh/F4/t2+7PauvGZFkFKLHxpWcykkbF9fdwLuB9+DMoAT4zz6tXE4yxvy3+9zunhcZY9qA1+NknH8EuC0LYxmO7hM/5ahhBzIRWSkiW3H6kW1110NXZDo6VViD9f86UV+wvjrjqePasBhjuOelBj766y0cbI3i8wgfu2ghN75jORWhE/f7auyMUR704fd6erMR89GhWhVWfVc9QW//ljxBb5D6rvpBXjGy1wybbUGsDdoOQOdrkMzo/9PR+jZO25aeYJaVNi6u3wFX4wSzu4H7gX9yW7IgIrUictzSh4hMATzGmP8BbsDpa9bXLqBGRM50n18uIj5gI/Be97FFOE2Zdx3z2r7PuQg43DOjy1QmS4s/Bz5mjNno3vh8nEzGIfuUqeLi9ciAQevYahqD6YimONLdv+RUNJnm+w/u4eGdzQDUTApyw5VLWVpTMdAl+vF7PVSG/cyfUuZ2qD763irXHapV4dWW1dISayHkO1o7M27FqS2rzeprTigVg3iHE7iy1BEkY1/tuI+vTvo4OchaNMZsE5FynJ6QDUCDiCwFnnbfOHYB7wOOPTtTC/zCzY8A+OIx102KyHuAH4pICGd/7FLgJ8BP3clPGrjWGJM45sjMV4Gfi8hLOEuoI96qGnYbFxF5wRhz+jGPDdqDbCS0RFXuHbtH1uPvTqs54R5ZW3eStmNKTu1t7mLthu0canOWsy88eQqfffNiyoJDv0c69jzYYzubWbN+G36vEPI7af0py7D27ct1j2wc67vfFfQGiVtxUlaK688e3h7ZcF8zINuCRCfEO8EauAoNvhKoPL6u51CSVpKklaQsUKYptnmSSSD7ARACfotTe/E9QBz4FYAxZstoB6OBLD+uWfcUT+9v6/38DfOr+O2Hzx30+Y/tbOZHj+6lri1KjVvr8Mz5Vax/sYEfP7qXtDvDq60M8YmLFnL2wsmDXktEqAj6qAofn0r/2M7mvHSoVsUl71mLqbg7++o68exrmIEsbafpTnXTneomaSUJ+oLMKJ2hgSxPMglkjw7xZWOMedNoB6OBLPcynfk8uqOJG/5vGx5x+oDFUzZJy2ZaeZCt9R0A+DxCzaQSQIbs3qwdmlXBDGf2NZAhAplt7N7gFU/H+31NA1l+DXuPzBhz3IE2Nfase2Iffq8QDjj/9OGAj2gyzbon9h0XyGzb8MNHnaLAPdU6BDjclaSp09knC/m9zJwU7N1ji6Us7tpU1y+Q+b0eJpcFeu+pVN4ku53glYpmZe/LGEMsHaM71U00HR2yUazKn0xqLU4HbgJmGmOuEJFlwBv6pGyqMaCuLUrlMVmEA2UHpi2bxs449e0xKoI+jDG0x1K0dB3dIysP+pheHuh3wLlv92aPCJVhP5NC2htM5ZGVcoJXotOZiWVBPB2nK9VFLBXDMtm5psqeTN4i346Tpfgl9/PdOCmdGsjGkNlVYTc78Og//bHZgYm0RVNHgrRtU1MRoiUSpz2WotstBuzzCAunlBEKeN3uzUevH0/ZzJgUcuoihgPDzoZUalSMgUTE+ZUa9jnaIaXsFF2JON0RIW2fsNyfKqBMNiumGGN+D9gAbiFHfWsyxnz4wgWkLEM0mcYY52PKMnz4QqeJQXciTUP70YPO5y6cTGNnvDeIhQNeJpcF+MB58wbs3mwb+MTFC5lcVqJBTOVeKg5dzdC6z/k4yiCWti06Ul00xFqojzbTkYpoEBsDMpmRdYvIZNxu0SJyDtCRk1GNcz3ZeXVtUWaPMjtvsGsN9vhFS6axFgbMDuybXm+M4e7Nh7h1434s41QAKS/xMX9yKdecNad3D+xTnMxdm+poisSZUx3mo29cqJmGY9CYql1o286yYaIT0oN3IB8uy1hE03G60zHiVuLELxgH3HJVtxhj3p3h624DvmeM2T7Ecz4CRI0xd4xymMMfVwZZi2fg1M56HU5V5KnAu40xL2VrMBMhazGb56UGu9a7z6jlD1vqh30Pyza0RBJEk847z45Yim/et5Nn9jnleeZODrNm1TLmTyk97rUlfi/V4YAW9h3DsnYuK9dSMWfvazhp8ydgjCFqxelKR4lbicGTNnwBKK/J+PojzVo85ZenHNfGZev7t+atjctw26YUm0yWFhcCVwDn4pQ32UNmMzpF/6xBEeej3ysjqik42LVue3L/sO+RSFu81h7rDWIv13fw4Ts39waxK143g5++94zjgphHhCnlJdRWhjSIjXF5q104Er0low5CR72zBzaKIBZNxzkcb6Mu2khLvJVYOl40mYduEDuujYv7+IgN0cblZffza0VkvYg8AjwsIh4R+YmI7BSRB0Xk3j4tWx4TkZXu77tE5OtuucJn3ITA3uu7vz9JRB5yn7NFRBaKSJmIPOx+vlVE3jGaPx9kFsi+7NbBqsJprPkT4KejHcBEU9cWPa7x5EhrCg52re6kNax79OyHpSwb2xh+8+yr/Ovv/kZzJEHQ7+GLVyzhc29ZTPCYa4UDTn+wiuCJayiq4pfT2oUjlU5ApMmpedh9JLOzX8dIWElaEx3UdTfQHD9CVzqKfXyvyGIwUBuXhPv4aPwOp3VLj6uAZ495zhk4K2xvBP4emIfTSmU18IZBrlsKPGOMeT3wBPAvAzzn18CP3eecCzTgFNL4O7cq1MXAd2WUac2ZzKh6EjuuBG41xtwjIl8bzc0nouFkDY72Wj2dm4e6R3s0SWu3s7/QFk3yjb/sZNMBp9rHgqmlrLlyGXMm9x9TwOdhcmmJzsDGmZzULhyJnszDeIcTyEYhZafpTkfpTsdJ2SMPgnmWzzYudcc87UFjTM+9zwfudjtDNw5RDCMJbHB/vxm4rO8X3dqOtcaYP7njiLuP+4Gb3P5nNk49x+lAZi04+shkRlYvIutwSlPdKyIlGb5eceKswWxc64Pnzx/0HrZtaO6M9waxF+va+dAdm3uD2NtOreHH15zeL4h5Pc4y4qyqsAaxceja5deSslLE0rHeA78pK8W1y6/NzwDSCehqOZp5OMIgZhmLzlS3m3HYRHsykpUgJllK5x+GfLZxOdZIyvynzNF1WYvhT4zeixNQVxhjTgOagODQLxlaJjOyq4DLge8YY9pFpIbRT3knnKGyBrN5rf2Hu47rAn3eyVOob4/x8437+N3zdcRSNj3fheGAl3e8fiY7GiJce/um3pqKlyybTnVp5ufBspmZqXLrglkXcD3X5zdr0RgnaSPe4aTQj5BtbCfj0IoRS4/8Ov0valHSspNw3SZCh57HqphJ07vWZefaQ/s2R7s4R8l+G5dbgSnAG93rDuavwPtF5Jc4Aeci4DeZ3tAYExGRQyLyTmPM/7qTHy8wCWg2xqRE5GJgbqbXPlYmJaqiwB/7fN6As96pMtSTBp+ra93y0G7Wv9SIR8DnE2wD//diA5XhABi4/emDAPTd4j5t1iQe293idmj20RZN8OPH9jJjUnBU2ZSVIT/NkThr1m9jrTteVXwumHVBfjIUrbQTvEZRdcMYQ8xK0J2OErWyk6zhSXQRqt9C6NAmQvVb8CYiR+/X+RqS6MKUlI36PkPZ+v6t953yy1OOa+OSjazFY9u4iMi8IZ7+P8AlwHacJcgtjPyo1WpgnYisBVLA/8PZN/uz2+LleWDnCK/da9jp9/kwEdLv8+HUr95PLGXh83h6f8jTtk2Jz4tlG+LpoxvdHnHqJxrozUD0eTx4PUI0mWZaeZDffuicjO5/zc+eOW7vbqTXUuNEMurOvkZe8zBuJehOx4imY1hZSNbwddQTPrSJUN0mgk3bkWNKTyWr5hGdcw6xpVeSmL4cPMNfVh/rRYNFpMwY0+WeHX4OOM8YM+I9rFzT9PlxqDtp4fM471zNMY/35fMIXo9gG5uU5SwvZqND83DrOapxzraOJm+MMOswYSXpTsfotmJYo62baKcJNm0ndGgT4bpN+Dtf6/dl4/ETqzmF2OyziM46E6ts6ojPkY0DG0SkEggANxZzEAMNZONSacBLNJnu3dcyxpA+5g1swCu9AcsYZ2aWtg0B39E3kdnOptRuzxPEKA8up+wU3ekYXenYqMtDeeKdhOq3OPtd9VvwpPrnNKRDVcRmnUl09kriNadh/KPKORg3jDEXFXoMmdBANs6kLJv3rJzFf//1ANhOMofVJ4gtrylne0ME2xgEgzFgG3jH62vY/GoH0WS6XzWQkWZTrlm/LSvXUmOElXbLRkVGNPuyje0GrygJaxRlp4zB31FHqM6ZdZW07ESOWYZMTF7oBq8zSU5eCKLJ12OdBrICGElG3y0P7ea2J/fTnXTOiX3w/Plcd+mifs+JxFMc6UpyzdlzeW7/EV6sP7ph7RX46tuXc95JU7jpnu08sqsF23ZS69/x+hl8/+ozBrzHSMeVrczMEdv9IDx1M7QfhMq5cO6nYNFlgz59qFqDY6oOYT6NsuK8k7Th1DgcVdKGlSLY9DLhuucJHdqEP9J/Fcz2BojPPI3orJXEZp+JFR68g/lIGWM4HDvM7rbd7GzbySvtr/CbKzNO9FMjpMkeeTaSWou3PLSbmx9xGlx6xJlB2QY+9aaTuO7SRdi24XBXgq6Eswzz00f3cveW/lUZBLj2DXNZPKOCWx7dQ9DnIRzwjbg+43DGVTC7H4S/fBY8AfCHnP9k7SRc8Z0Bg9lQtQaBsVGHMJ/SyaOZhyP4/yNuJehKx4iNImnDE2snfGizm2X4Ap50/0CaDk8hOnslsVlnEq85FeMbKtt8CIPskcXTcfa072F32252te5iV9suWuP9zzJvff/WMZvsMdbojCzPMunQ3OO2J/c7qfQeZwnE2c+yue3J/fzzBQs40pXsbbvy9CtH+gUxr+AmdBh+v/kQS2sqCPm9x93/tif3M7W8JGvjKmgge+pmJ4gF3D25QNipQfDUzQMGsr61BoHejz21Bgf72oQKZLYNyYiz9zWCA8spO0VXOkb3SPe9jMHfdsA927WJkpbdSJ9UJoOQnHIy0dlnEpt1Jsnq+U7Lhiywjc2hyKHe2dbu1t0c7DyIzfFBOOANcFLlSSyrXpaVe6vh0UCWZyPJ6OvJQuxLMHQl0jR1OodAU5bNbRv3c/fmQ73P6clKBPC4/cIaO+MD3r87aTEnwxqQA43LI8dnR+Zd+0EIVvV/zB+C9lcHfHp9Vz0VgYp+j/WtNTjU18a9ZNRZOhxB4kbatui2YnSnoiRHUGFD0kmCjVsJ1T1H+NAmfN2H+33d9gWJ1Z7u7HfNWoEdqhrkSpnpSEbYFTnArs4D7O56ld2dB4mmB/45qC2rZXHVYhZXL2ZR1SLmVczD5/ER9GnSSD5pIMuzkWT09dRO9Ai9+wi2obcwcGNHnBvv2c6OBmdPrOdsWE8QE8AyUFbiG1V9xqHG1cM2zuMFVTnXKTgb6DP2VAwq5wz49BPVGiyKOoT5ZFvu0mHmiRs9SRsj7e3ljbYSOvQ84brnCDa8iOeY2V+qbJqTHj/7TOLTXwfe0RWuTtkp9nXVs6tzf2/waoofGfC55YFyFlc5AWtx9WIWVS6iLJDbQ9JqeDSQ5dlIMvo+eP58bn5kLynL6rcXddWKWTy55zDfun8XXYk0AvzD2XPwCfzymVex3Jx76XOdU2dV8rk/vEh9W4y0bePzeCgP+vjg+fP5w5b6EY0rbdv9xvXB80dV43T0zv2Us0eWpP8e2bmfGvDp1y6/lpuevQmg3z5YT63BNU98nteSESyc+jrlgXI+tzK71dl++refcueOO4mmooT9YVYvXc1HT/toVu9xQsmos++V7M5o9mUb2620ESOWadKGMQSOvNJ7tqvkyN7+XxYPialLiM1aSXT2WaQqZ494ydAYQ1P8CDs797M7cpBdnfvZ11VPeoD2Wz7xMq+sliWTFrJ4+hksqlpETWkNoyzSrnJEA1mejaTW4kcuOolIPMVvnqsjlnJatLzr9Fo64mnWrN8GQFXYzxevWMLKedU8t6+V8hIvkcTRJb6KkI9TZ1UCPS2+cX4oxfn81FmVnDqrMqNx9eyDnSibMu8WXQZ8x81afNWZiQ2RtThUrcGNz96CiUcQcf7/FAMmHoH6FyBLe2Q//dtPWffSOkQEn/iIpWOse8mp7ZfzYGZbTvCKd2Y0++qpcRi14hkHL0knCDa8SLjuOUKHnscX7Z8kYfvDxGrPcPa7aldgBysGudLQutMxdncecIPWAXZFDtCZ6hrwudOCk1lcPpdFFfNYUj6PBeWzCXj8E/lA9JiiWYtFzBhDezRFeyzV7z+K+vYYN27Yzu4m54fytNmVfOmtS5hc5mRmfe7ul2iLJigtObrs0lMiCtDyURn459tX0mInCMnR5dKYsZjqKeG/r83O9+q5vz2XWDqGT47+m6RNmpAvxFPXPJWVexwnFXOWDzOYffUt0DtkV+UBeLtbetPjgw0v4TnmrFiqvIbo7LOIzV5JfPpy8GT2HtsyFge7G5x9LXeJ8FC0if61bRwhb5CTy+ewuHweiyvmsahiHlWBQYJlnjtEq5HRGVmRiiUtDnclSFn9M6Me29XCdx/YRXfSQoB/fMNc3nfOXLwep1LH5LIATZGBEzoOtUUxoOWjMlBvJ6g45sBsUDzU26Prl9VXNBXtF8QAvHiJprL8bzKC2ZdlLGLpRObBy9gEDu8h7B5MDrT170RixEN8+vLeJcP0pMz2HI8k2p1ZljvT2ht5lYR9/EFqD8Kc0hoWlTsBa0nFPGaFZ+DVQ9DjigayIpO2bI50J+lO9F+3T6ZtfvLYK6x/0akPV10a4EtvXcLpc5xMLa9HmF4RJOj3njChRMtHDV+tp+S4GVnc2NR6RnguaQBhf9iZkfX5cbSwCPuz9G+S7HaC1zAL9qZti6gVJ5qOkbCTww5ekooSeu1vTlWNQ8/jjfcvmG4FyojNWkFs1pnEas/AHmY1+biVYG+krnemtavzAEeS7QM+typQwSJ3prW4fB4nlc8hrBmE454GsiJh24b2WIqOY5YRAepao6zdsJ1XWpw6cSvmVvHFK5ZQXRoAwO/1MGNSEL/XeZd5ooQSLR81fNcu/Udu2nYrGIugeIgbm5T7eLasXrqadS+tI00aL14sLIwxrF66euQX7Z19dTjlo07AMpazbJhhtqEv0tSbqBFs3Iocc0YsOWk2sdnOrCsxdckJK8jbxqY+2syuyAF2u7OtA12vDXxmy+NnYdlsFpXPZXHFfBZXzGNqSZUmZExAGshGaSTlpo59zepz5rC8dhK3P7mf328+1JvQcdWKWcysCvG9B/f0prl/4Lx5XHPWHDw9FeoDXqaVB/s1vrxoyTTefah90HJTBS8flS0ZlqEaiQvOvo7rgdt33EG9naDWU8K1S/+RC86+jo3P3jLw4xmWtOpJ6BgoazHj0lnTV8L2P8Nz66CzHipmwunvh3nnDXhvJ3hFeaJ5M/9T9yBNsSNMD03m72dfysrq5ce/wLYoadnVG7wCx5zNMx4f8enLew8mpyuG3l/qSHU5AcsNWns6D9JtDVzuqjY0jUXuTGtxxTzmldbiy6C1ihq/NNljFEZSbqrva0p8HroSaVKWYXlNOY/sanHOgIlTSMHq808zpSzAl65cyuvdzEOAipCfyaWB496BjmRcY06GZaiybeOzt3DTtlvxQ7+Z2tvnXs769pezUtJq2KWzPCXE0zFSVoLrp5zHBS/8Hjx+8AUhHQc7BRd+vjeYxawE0T59vZ5v3cZ/7fk9fvES8ARI2klSxuIjJ1/FyurlSLKbUP0LTu+uQ8/3azoJYJVUuHtdZxKbeTomMPCSaMpOs7/r0NHDxp0HaIgfHvC5Zb6wu0TozLYWlc+l3F+a0d/fqIlAoBRGUJtRkz3yS2dkozCSclPrntiHz+MsB6YtQ9DnxRirN4h5PR5sY7D7vME4a341X7x8CZPCR5M0JpeVMCk08GHQkYxrzMmwDFW23b7jDvzQu3cWEi8Yizvr7mdK5byslLQasnSWMfjFS0h8YKcIeXxgp7n9wHou8Pihpx2JPwgpSLxwO101y4la8eP6ev2x7iH84qXE6+z7lXhLmBntILb550y3QwQbtw3QdHKuk2U460wSU04+bsmw58yWs6/Vc2brEKkBzmx5xcP80lonYFXMY3H5XGaGpuV/idDjBW8J+Eucj74AR09hqmKmgWwURlJu6uCRbkpLfNj20UAV9HuwDXg9YNmGdJ+vCXDT372udynRI8K0ipJ+yRrZGNeYk2EZqmwbLJsxik3Q2z+5YKQlrQYsneUpob7zVTA2Ff4y6FN0N+gtod4kwefMXOIYokDUHyDd1QjH9OLq0RQ7wiRvkGVdHayMtHJmZyu1yXi/5xiPj1jNqW7TyZVYZf3fEEXTMfZEXnUPGx9gd+dB2lP9Z249ppZUOXta7t7WgrJZlHgDmf71jI6IUxWkJ2D5ghmn/Kviof9yo5BJual4ykmnn1Ye5Eh3ore8lPM1GwHSFv3OvXgFgn5vbxDzeTxMqygh6B96X2BCNLbMsAxVtg2WzRgWIW7Fs1LSqrd0ljcExgLbIp6OURuaAkBLvI1Qn4y8WDrODPFz2IoR85fQO4dKJ6Bs6nHX9yQihA5t5sbGBk7pPEz5MTO1Nl8A3/w3OuWgal6P8Tt/JsvYvOqWdeo5bFwXbRzwzFbQE2BRxTwWuYeNF5fPo7pkUsZ/F6Pi8YI34AYunzOT19nWuKKBbBSGU27Ksg2t3UkicefcztVnzubmR5zkjaDfQzxlO8kdAS9Rt9iu4NRLNDhlqOD4zMTRjmvMy7AMVbYNls24evZbWN/+MjBwuauM7rH4am7a9G1IJwl6S4hbCVImzbUL3gnATdtuxaRiBLwBYuk4SZNiVe2b6Or4C6RxZhtWAuw0LPs7t+nkod4ivCXNTtPJviHulWApz5RV8FRZORef8n5WTj6F1kQHuzp29+5r7YkcJD7AmS1BmFM6w93bcmZcs0tr8ndmy+tz9ga97q+e3+uZsXFPkz1GqScD8dgMQGMMnfE07dEklt3/7/jOpw7w+82HiCYt/F7BssEyxm2JIqQsQzjgZC2uPnceQb+XnQ2d3Lpx/3HZkYM1thxsXONKb9biictQ5cJPH/4cd9bdTxRDGGH17Lfw0Uu+PaJGnBvvvY7bDz1AvUeotQ3XTjuXC86/no3Nm7l93/9SH22mNjyNaxe8k/OnnkHMinP9k2t4tGsvNgYPwgVlC/jsys9A/RbY/ifoaoHSyQRnnEY41j5k08kdVbX83GpmR7qL8kApC8tmE03Hk+bp9wAAIABJREFU2RU5wOFE24BjrvSXO5Ux3CzCk8vnEO4zE82ZnllVzwyrZ7ZVRDMsTfbILw1kOdCVSNPWnTyuKgfAc/taufmRPXgEOmOp3nqI1WE/N77zdSyt6b8nEg742PFaB1/58/bjshBXzJnE+pcai6+x5QQwVEZhxtmJ93ySmxoewm8MQQNxgZQI108+mwsuuAGApJUiZieIWwkSVpJfv3gbd7VuRhA8gI2zLH119Qreu+hdbgX5TYReewFPauCmk921K9lXWcPOaD27IgfZ3XmA/V31A57Z8ouPheWzWVTuVMdYVDGPaSXVuU3I6N3HCvT5GBgTMywNZPmlS4tZFE9ZHOlOkkgN3o/rrk11TkfnaJKUm18f8nuYWRk6LoiVBX1MLSvh07/bP2AWYk8QK7rGlhPAUBmFww5kySjEO7j90IP4PRACEPejMfy8+Rlel+wcsBnl/7VuQRC87nMXp1KcH43xxoZ7mb3l//o1nQRITDmZhtrT+FtVDdtM3Nnbqrub7v0Dn9mqCU09WouwfB7zy2rx5yoZoidgeQL9Z1iafKGGSb9TsiCRtmjrThFNDl1BwRjDK4e76IqnMTgLIVPLAlSEfBzu6l9NYVLI31sEeLAsRMs2+Hz93/QVRWPLCeBEzTgHNUC9w3qvUGEbjPTMrMBj4FWv0JEcOPPPsm3Ojye4MBbjgmiMGqv/v3nCF2TrzGW8UFXDVr+HndHXaOh8FjqPv1apL9QvaC2qmOtkRGZbb8Dqs4flC2jAUqOm30GjkLZsWqNJuuInLgHUlUjz3Qd2E3Gf6/cKNW5txFjKYkbF0b2F6tIAleGj6ciDZSF6PYJtKL7GlhPAiZpx9mOMU+dwgHqHCSvJNMtw2AN9E9ATAtOP2VvtaToZOvQ8j9fVE3avY4DXfF4eC4V4pDRMpGoOexKtpMxh6Ox/4NiDh3llM1lcMZ8lbiHdmaGpeLK9XCfiBClvydElQa+PYtrHOhGvePF4PM5H8Rz9hQcRp0i3B+cxr8fb+3uPeLRMVp5pIBuBoeoiDmRXY4S1G7bT0OGczQn6PUwuDVDi9xBLWaRtw9VnzgYGPug8WBbi20+dwfqXGouvseUEcKJmnICT9h7vhGTEKdXC0WryMStO3EpgGZu3Tz6N/2p/EWMMAZxEzJQIf195qtN0sm6Tk2V4eA8A3SJsLQnwUkkJT4aC7CgJEPP0CUTx5t7fTimp6teuZGHZbIK5OLPVcybL3yd4FYm+AUmQ3kDTNyj1BCufx+cEJvFqMBpDcprsISJB4AmgBCdo/sEY85XBnl/MyR6P7Wzmvx5/hVdb/397Zx4e51Xf+895l5n3nU2WbVleJEdZbCXxEtvYISEklwKBUIJ7CblA2oa6FwjQ3ALtpdDmXkqfXpqS0uWG3hYaCg1boTRNaFogQJoGQkJiO87mxJYc27Jl2ZYX7Zr1fd9z/ziv5BlpJEuyNKPlfJ5Hz1jvel6NrO+cc77n+0tTn3J4z9ZGrr5EFbH8zq52TvRlWJFyee82tR3UUOKDz3Xwdz89hBdIbFPw22+8jLp4lH/afYyTfRmWh+e89tIl1CWjJKLlP1v8znf28PCLJ/EDiWkItm9czl+9d8uY26eSATklJpt3+Pg98PTfQG4Aogm45k54w6emdK2xsg5hjBzCsFDmWOdMlrL3WHkdv/+z3+ORo4/iywADwVuWv47/teEOMn6O3NGnQ0fhKUgsU7b4VVv49k8/zb/6Z5DA9ekMv5aDDT6IdBcHbVsJlxPlxWiUg7aNLPM31sLg8ppLhgN01yYvYkn0XKTZ7q6XebD90bJ5iuPtG4VhhAuJixIwJtCj2925mwcPPEhnupP6WD23rLmFrfVbx9xe9taiVHhG9ZbCbZZhYQoTs7pZjFoJK8RMC5kA4lLKASGEDfwc+JiU8ulyx89WIXt8/yn+97/uxRAQtdTaLy+Q3HRlPY+80olliOE1YV4g+dgb13DFyiR/9qMWnnz1LACNtS5/ePOVXLps9NyDIVQJFneMIcEvPNrKvY+9OsqduH3jcp492jvKzXjrllU8sKdj5rMWJ5t3+Pg98LM/Q5WnVpFOIOGGT8LKLZO61lhZh3et+yCs2lzWUbh90XoePvJI2XOmKmbAuaHDXD+///Rn+f7xn4465L/UbeUTNRth15fVnFDRGq+X69fQeuoFXpfJ0OAV2B+J8FI0wkvRKHujEdLGaJEQCBpi9cPzWpenmlgdX4Epyv8OjZenCIydtbhkfTiPFVHCZUWnNKe1u3M3X3rhS9iGTcSMkPfzeIHHjRfdyKNHHsU2baJmlFyQw/M9PrH1E1y36roSsaqyKE0FLWQVomL2eyFEDCVkH5FSPlPumNkoZAU/4D1/9wtO95emcWQKPl2DeRbHI6O2O5ZJX65AZ58ycNx4ZT0ff9OaskJVXEdsLDb+0Y/IFPxhdyIod2IgoWlJbFS159P9OeqS0ZmvAn3/zaPTNfJpSNbDjn8fffznVqv9ZtEfQt9T5y/fOKlrjVe5mRVXjZq/yngZzvS0sTSQ01ftuZBBZvvIZbvIecoWf+N/fICgTMKFgeBf84sg0wNmhIiXxcwN0iaz7LfN4R7XCau8SBjCwDEiWMJkSXQRf7rp48QnsWbrrhfupTvXO5ynCJDzc9SGKRvn9gkQBrkgT62zmLuv/9PJ/UzCtpqGqXpEYa/od/7zdzibPYtruQjU/FLGy3Amc4al7tJR71WdW8dX3vqVSd97lqGFrELM+ByZEMIEngUuA/5mpIgJIe4A7gBYvboy8UITQUpJd1rNg3X0ZEg5pT8qJ5zfcmyj5JxMwae9W1mao5bBR9+0hretX172Hpah0joi1vjDMoN5n5GHGAIKviwRUVBuxsG8z+oy26c9a3GyeYe5AeVUK0aYavskrzVu5eYxHIVpJM4FVHuWUpLL9pLLdpPPdJH3chSC0krL5UQMIBL4nO1r56AlaJGSva5Na00cT4zuoQspiSDIIVnmLMExo1jhnI2UkgEvPSkRA5WnmLCKI8oEEdOhM9sNQpCwkyWuoYjh0Jk5N9cmhMAyLCxhKWNDcU+p6HVo36j7pztJRVIl806O6ZAupHES05NNqVm4zLiQSSl9YJMQYhHwkBBivZRyb9H++4D7QPXIZro9E2Eg59E1kMcLJ+hXpNyy+YiubQ6/+oHkZF922Pp+0ZIYn3nHlTQtKV96YjKRU/GIOVyPbAgVMizIFPxRbsah42c8a3GyeYfRhOplFf/aSV9tn+S1xq3cPIajMIYgK4Nxqz1LKfECj0JQGP7yCmm8bC9+rh/plwrXSAzEsJgt9nxW+h4B0GFZ7Fha3tIeDwIkAheBIyGKIC+h2xREDKtk/VY+yFPvTrKsiGFQH1tGd76PqOmgel2Q93LUJ1S9sO5sN47hIMJ9OT9HQ6KBZbFl2IaNZVgXZH4Yy+UZs2PTlk2pWbhUbIm8lLIH+E/gpkrdc7LkvYATvRlO9WWHRQxUPqIXqN6WRA47Dd/9mga8QNKTyXOkKz0sYlsvquWLv7ZlXBFbMUERA+VCDOTQcGIwPKy4feNyCr4knfeQUr0WfMkHXn9x2e3TnrX4uo+peax8aCnPp8fPO7zmTkCq4cQgfEWq7ZO81o4r3kcBNTQokWSkP1y5ece6HRT8Ahkvo3rJXoaCX+D2xrcOnxMQMCh9ssB/vexddAx00N7XzpG+I3QMdHBq4DjdPW0MnGkl23UYL901poh5gc+r/Uf5/rHHudiIsyhc09VlmeyNRnklGqXXVOKZCAK25jxuy8IfDsI3e3w+kdxAUoIbKFdUXkJBSH5l8RYK0ifn51Rv0M9RkD63NL557PfEMFRP1l0EiWWImgas2ot5z5W/ji8lhcDDFCZe4BHIgA+s/wB3bLgDKSW+9LEM69y+DR8gZsewTfuCHXxjvidX3F52+1SyKTULlxntkQkh6oCClLJHCOECNwL3zOQ9p4LnB3SnCwzkvLJ2+qsvWczHWMN3drWXOA23XlzLix29PHu0Z/jYGy5bwh/9yvox7zUkYtYERQwYTumYTKbixoZFM5+1uPZG4M8nnnf4hk/B2YPw8gNqMbBhwrpbz7kWj//qaEfjGNcar3IzwF0db+Mf9n2NjiDPCiPCbWvfy7Yt72dVupd/OvEzThqCeim5pf71bNhwG4WDj8Oer6mqyvFlcMV2WLUFKHX0LXMW8+bl1xA1I7Qcf4bWrv28KjzyxX/oQ9EypeSSQoGVRLh6xdVc0ng9K9t2YrT8G+SzEHHg8u1s3fhuPtz6MA92PEanLFBv2Nyy6o1sXbudNeO4CS3DwrIcLDuGGYlh2gkMK1oyR2WFvbmGZAOLncVjZkCahlne5TmF3Miy71fD9dzFXWWvtX7p+mm5h2bhMtOuxY3A1wAT1fv7rpTyj8c6vtJmDz+Q9KTz9GXLC9h49KTz/P6DL9HaOQBAxDJYHFOfXD/2xjXDFvxiorbJ8pSDaSzQOeDxXI4wIddiIFWvdKgHMfwVqFcv8PAOPo7/07uRI6skX/4O2P9vpdWT/TyseSu0/lDN1xUnxm/7IE9FDL504Lvq2tIn6+fLZhECLPM8NubyXClirFlyOatX34CxbN25opMde8q6Ftn2wWHRLEYIgSUsLEMJkm3HsWwX23Kx7DjCdlUPbIaYzjzJBcoC/Y9eeRZsaHBvukB3Ol9SiXmivNDew2e/v4+zg6qURY1jUZeMYgg1Z7UkHuUv33NVyTlOKGLGQhUxGNPlKJPL8AC/vxMvEsNH4gFBIYOfWIp/61cIgoCAYGIfOB76EAyeUYI4RCED6bOqbL3lqIKUw4kb3eDUElgR2oWkxQxoFR4tlkmbUT7uyw0Crszl2ZjLsyGXZ21gkDBsMsnleG8bY9DhJ59WrkXr3Jyc8HLYbi322z6PHZopLMvGtOPYdlwtNLacsH5WZXn/j95f1v05TxyFlWAB/2evLAs22aMvW5i0iPmB5B+fOcrXftFGINVvaX0qSso558RzbIOTfaVBrLGIRX0quqCTAgpBAa/nCL6zCI8AD/CQFCIR/L7QmRhNgSjq7dhRNdR3HoPFKPqOq2sVYzmQG4R4fXg9STeS1ohFi7BojQlazRyZkrfonIhdki+wIZdjYy7PxlyOxZ6PG0mQiSbIxJYiDYN+CWR7yzbJEAaRgVNYkRQRCTbqyzJc6DsNi5rCdVpuVUSrHFPOk9RoKsyCFbLJ0jWY5+4f7GNPOB922bIEthAMjAgKzhaCktzERFT11uaziPmBTyCD4WG+IdefF3h4gYcvfdWTWrSyTE8pC6mV6t8j93lF+yZDqug+MoAgIF8Y5FA8TouRptU22G9IThnhBxk3AUXDhTV+wFW53LBwrc/lSAWSg06c3alavrg0wRk/x58MBCW9K/wcIlGHbdjYhkXEsNUCYMPGMkxIrITBs2DHVBKGEOr5l1yiUj5mGZPKk9RoqogWsgmw50g3f/KDfXSnVc/gnZtX8aEbLuH5oz2jqj0X5yYmHZu6ZHS8S886hoRnSJyGhvOGhGpojsqXPkGgXifM5vfBz+6BAqVzV5vfp/aPt2+iyAC5/t2c+MVf0uLnabVMWiyfw67EE8nwoHOiZUnJmsDkqsE+NmWzbMzlafA8BBAYFp11l/IVkWZPspa+aOJc6kXt6zFf+SGRAkQsh0ghix142Jv+OyI2QpRMW4nq6z4OP/nfal5saB5QFipW1XqyTChPUqOZBWghGwc/kHz9F2188+mjSCAeNfm9tzZzwxpVHH4sN+PVlyyeFSIWyGDYBDFshAi/JLLEODHh+acLoek6dvfdyoMHv0dn0Ed91OaWS29la9N1an/rVXDgR6rUiWEqE0bTdefN4hvI9dF65iVazu6ntecALX1t9KeGTBBDQqt6xPVYXDnYx6Zsji25HFfk80SLHvuMafJYIonTcC0NWz+ItKJk237AgWP/SWawF9d0uK3pl3ln823cVxjkG6efIk2aGAa3193ARy77JTj6DOz+CvQdU0OG131cGVbWbVcCNpmq1pPNspxGxnMaTpebEcbOxdRoJsqCNXu0d6XLVnAe4nR/jrt/sI8Xjqk5j+blSf7w5itYUXP+RIWEY7Es6Zz3uMkw5NIr7hkV94pGbZcVEKZJUi5vrxAU+PBVH2brkeeUo29EDuPu9dv5Uq5t+JyclyPjZ7im/mqy3iAt3QfoSJ8se7+Y6bA2eRGXR2q5anCALW27WDFwetQMfJdbw8Nxl93JWtpji8jLAgXp81tr3kPEsPnr1n8kImxcyyHr5yhIj6tqmnnk5JMIVLq6LwMkkg+tupGP7P3xxPMnx2OyWZYVYlqrY89vZ+T8nU+YZWghK8POw1386Q/305tRQ4nv2rKKO264ZEILmBfFIiyOjz9ZXzxUNzR/NEqMAn/UcN5c566f30V3tpto0bxSzstR69Ry9ytPqT/UI3IYf6+ullOpevxALQzO+TnkGFmGF8VX0pxqojnRyIZcjuaTB4h37MYeOFVybABkDZO0YZIBPrVsCd2LVhE1lfNUYJDz89S7agnF6Ww3rhV+MBEGGT/P0YFjw/b4ITzp4fo+T/VHJ54/OR6TzbKsENPpZpznzkgtZBVCDy0W4QeSrz55mG/vbAcg6Vh88q3NXHfZ0vOeK5EsipnEogHpQhpPesPDesVDfPNFlKZCZ7qTxIjKwxEzQme6E/JpsqbFAdtSTkLbpMW26DJNyHaNupaB4LVLN7I2rLXVbCZZfPIl3PZduMcfwvCyJcd78TrS6bNkTIusaSJD840VSE4bghorVlIQ0RQOHelTIASpSI0a6gz3OYaFL32ionTo2MQkjVdqWIHx8yfHY7JZlhViOt2M2hmpmQ60kIWc6svy2e/vY+9xVQv+yhUpPn3zFdSnnHAIL5xnkh7BiEW4AT5L4jb9nkn/+YtFL1jqY/XDPTIpJYWgwEB+ACEEH61fyhHLICjj7hRA1IgQNaM4ZgQB1EVr+aPlb8I9tpPYiz8ieqa15ByJIFfXTKZxK+mGbRRqm+Cfb8co5HClWgfmSInt+6z2JaeDgup1CQOEQdbPsaqmCUD1GIp6Xlk/q4YT8bGK/gv5+MQQqmc50fzJ8ZhslmWFmE43o3ZGaqaDBSlkfuBTCArkfFXh+elDXfzVTw7Tn1XGgF/ZvIR3X70UjC6OD/rjzjUZQrA0GSV6ngT7hU5vrpf1S9fz8KsP40mPvJ8vGSLsKgpkXlXwaM4XaM4X8Fds4nuyh4hhkcDkiv6zbOvv5k3Zg8Sef6zkHoHtklm5mXTjNjINWwkcVaLENmxSZhR33btxdv9DGIxrKGs+kh0r38DduTYgwDEiap4m8IbdeeWcezc13cQjbY/g4WGiRE1Kye2Nb4W9P1ZlnovntabiTHzdx9Qc2XRcaxqZTjejdkZqpoM5LWTl5pZK7OFFc00BQYldvDOdJZv3+e7OLn74ouqFJRyDD/1SHZtWxwjIE5xnBNA0lIhFJpGbOKtpexKe+7paUJxaqazvQ47CSVDwCxzqPURLdwst3S20drVycgxDhits1tWuVUOEZ4+w9tCTJHKZ4RxC89I3sfSnn2FF/ylem83hjvhQUUjUk2m8mnTjNrL165TVHXBOvIi791+I953ESq2Ezb8B1/yWWnC85361ODqagGv/B9e/4VPcNY5zbvuZ7Xxj3zdIF9LE7Bi3X3E7H9n0EQAeaXuEnMxhCpObmm7iIzd8DhrfMjln4lhMNsuyQoznZqzmtTQLl1ln9njymSfLGh2m25X3Yns/9/64k4OnVC2qtcuj3PmmZSxOTEzbLcNgaTIy4QT7WU/bk2od18h8whs+Na6YSSnpTHeyv2s/rd2ttHa3cLD3EF4weozVwuBiz6fZF6yVNs2FAis8H1GcNSgDImcPEmvfhdu+k2jXoZJr+MDz0Si9qRU0X/d7FGoaQAhMw8Q1ojhmFOfYs1hPfF49ix0DL6fWa73tL6D5LZP6sYzlqtt+6XYePvjwfHXbaaYHbfaoELOqR+ZLnxMDJ2b8Pk+09PG573cwmAsQwDs213DL1toJh/lahkFdKlJSsXnO89zXwz/84VyF7arFyc99vUTIBvIDHOg5QEtX2NvqbqUv31f2ksuii2lONbE21cTlySYu2flVIpnec2kYhglGDrH3AVwvj3tsF+6x3ViZ7pLr9AvBk67Dz12XJ12HbtPAkR7/vLiJlOkSt1yiZkSZMSwHXvyO6nlFQ2OJFVFuv198YdJCdv/L92Ob9vAcztDrN/Z9o6Sy8dDr/S/fr4VMo6kws0rIKkHryQyfflC5ElOuwYffuIwNDROvtmuZBnXJeSZiUDaf0LeiHBk4TsvhH6phwq4Wjg0cK3u6a0ZZk7yI5tBFuDbVRO0INxoDpyGi0jVMv0AsN4ibG8DtOoI4sbfk0EJqFenGbfzumSd5KRrBD00gAlVKIWMIGmPLlXjZLkQS6sswoP/4tLn9xnLV6crGGs3sYcEJ2drlLjdvquXQ6Qwf+aU6FsUn/iOwTINlyQjmfBMxgNRKzqZPsz9iq+R3w+dV4ZNzgBf+tuRQA8Hq+AolWKFwNcSWY5YpcT9M4BO147j9J4kVskT8fMluKUyy9Veq+a6GrXg1yrX28mO7yYtzv6gCNbwYD6RaT2XHR5cymUa3n65srNHMfhackAF89MblnO7PTSr9fr6JWNbLcrDn4LAhoyXSz1lRQI0nllIbSdGcDIcIU01cmlhNzDp/conIp3GPP6fmuzqexRyRDO8Lg4wVJX3528muv4UgHAoUQuCaUWKmw+3xNXw58yq+lJiAB0ghuH3RVRBNjr4pTKvbbyxX3e1X3M7DBx8etV277TSayrMghSxiGRiGIPAnJmRzXcQCGdAx0EFLl5rTauluoa2vrezC7IiESz1Js+GwduW1NDe9kbpo7YTT+62+E7jHdhF79T9wutoQI1I48vE6MgLSMiBXswrW3QKrtmAaJonjLxJ76Z9x+04gUithy29y59vvw/jer/ON/DHShkEsCLg9spqPvPNbYzdiHLffZHP9dGXjmUdnLWoulFnlWtz8ms3yocceqsi9TvRm8cbJWhzCtgyWhUUz5wq9uV4OdB9gf/d+WrtaaO05wGBhsOyxq9xlrE01Dc9tNcVXqZIjEyXwiZ7eT6x9J277LiK9pXNoEshaDmk7SmbLb+CtefPwPseM4ppRXNMh0r7znGvSjqnKzUEBNv0avPCP05I3OM9z/eYk8/w9mTt/NOY4C7JHNlEitkFdYnaLWCEocLj3cNjbaqGlaz8n0p1lj01YMdYm1fDg2lQTa5MXkbTjk76nkRvA7XgW99hu3GPPYuYHSvb7hkXaipJxUmQicaRhKAt820+xmm8iYbnErRi2Ef76CQHPf0s5DSPx0H0YOg2f/htVDHNovisSU0OGT907aSEby4GonYbVQ78nmulAC9kYOBGDJfHZJWJDa7Zau1tp6dpPS9d+DvW1UQhGz2uZwuDi+CqaUxcP299XuHVTLvBp9R4j1r6LWPsuoqdeQYwYlszXXky6cRvpxm3kn/iLsNpzeC4QNx3ifaeJxOrVRiGUaEXiym04cEI5DYvbZ7uQG1ClUIqZZgeidhpWD/2eaKYDLWRlcCMmSxIRFWVURdKFtFqzdXYfLV2q1lbPGGu26qK1JUOElyYa1dqqqRJ4OJ0v47bvJnZsF3bf8ZLd0rDJrLyKTMM20o1b8eN1w/tEsp5ougfXcogBNmEl5NQKsB1l0ogkS92GYzkNo4lpyy7UuX6zD/2eaKYDLWQjiEVNFscrL2J+4HO09zAtXfvUEGH3q7QPHi9bssQxImrNVjhE2JxsYnG05oLbYGT7cDueDV2GezAK6ZL9nrtYhfA2Xk12+Uakfc65KITAMaPETRd3029iPvF5kLkwJSSn6otd/0moaSh/87GchtfcqebIZtCBqJ2G1UO/J5rpQJs9ikg4FrWxC+jFTIKz6VO0nnkltL+38mr/EbJ+btRxAsHq+PJz5UqSTTTGVwyv2drd9TIPtj9KZ+Ys9e4Sbml8M1sXrxv/5h174JWHoL8T26khlmrA7TtO9HTLqCHD3JLLVAhv49XkF19SMvRXLF4xy8EoXke2+6sqFSQ3CE5SCdIbPjVuxeMnnvkC9+/7Oh1BjlVGlB1XvI/rX/vRonMuPG9wKg65Mds1jSxk5948fvbZMy8xz9FCFpJybWpcewbuJMnm+jnY1UJrVwstvQdo6T3MmVx32aMX2UmaUxfTnLqItckm1iRXE7PKJ4/s7nqZLx34LrYwiRgR8kGegvT58Jp3jy1m7Ttxnv4iMS+PW8hgj8hEDKwo2RWbSDduJdOwFT+2ZNQlHDNK3FLiZYoih6NpqSHDo8/Aj/9gtNPwql8d04H4RMyZle61J575Ane//GVswBEGWRlQAO5a98FpE7N57txbyGghqxB6aBFV1TnpTMOPQgYEhSzH+4/S2tXK/p5WWnsPcXigg4DRVn9bWFyWXM3acJiwOXXxpNZsPdj+KLYwiZoquzBqRsHP8WD7oyVCZmR6iB3bjdu+E7d9J8aIXpdnmKTdRWSuvZPs8g1Iq7RgJCjxilku8ZHiJYSa84omz+U0PvO3SqxGOg3HcSDev6J+VrrX7t/3dWzADZ/ZFSZIn/v3fX3ahEw79zSaC2PBC1ltIkIiMoUfQ+CBl6Mvc1a5CHsO0Np7mJb+Nga9TNlTVrh157IIk01cnFh1zoI+BTozZ0lYsZJtESNCZ/oMdtdhYu07ibXvInLmQMnCZAnkLIdMNE46kqBgRqAwCA1bS67lmFFcyyFuuqVry4RQa72iyXN2+WLGqmw8jgOxI+nNSvdaR5AjNSJ6yxEGHcHoYeAp30M79zSaC2JBC9mSRJRYZAKLf/0C+HkKhTRtvYdo6W6lJRStE5nTZU+JW+5wrJN6vYiUnZjW9te7S+jO9RI1o0QCnw0DvWzpO8M1A30saSne597nAAAR00lEQVQ1QwSWS2bVZjK97aSRBMUuQC8HCeU6jBg28XCd16iF0aYNTkpZ68dbND0FB+KqRP2sdK+tMqKcDnLDPTKArAxYZYzutU75Htq5p9FcEAtWyJYkIqMLYspAJUr4eaSX5/TgSVp61JxWa/8RDg60ky+zZsvAoCmxkubUxVweitdKt67U/DAD/Grd1bS++E2uHehn82Afzoghw3NFJ7eSrV+vhKhjD+z6shKvcCjSCjziG24jEVuGbYyYJzQMNe8VTSrr/ESYggNxRzhHBrPLvbbjivdx98tfBumXzJHtuOJ903cP7dzTaC6IBWv2GOplDb2mc30c6D1Ea38bLX1HaOk7TE+hv+ypS6O1w72s5tTFXJpoxLmQNVsTpbjo5LHdRM++WrI7ALqS9RhrbyLTuI1CTePoYT+Ajj2Yr3yPWP8p4snlOJt3lBbPHCqNEk2VHzqcCP9yB7z8AAS+6r2tuxXedd+4DsTZ6l7TrkXNFNFmjwox/4WsqJc1JFq+l6N94Dgt/W209LXR2t/G0cGTZddsRY0IlyVXc3loxlibvIgl0UXT28ZxEIUszokXiB3bhdu+GyvTVbI/QJCJuKSjKTKmRYCE4orLRRjCIGY6xO0YrllmaGxo6DCSVA7EqfL4PfCzPwMEhOYIkHDDJ5UFX6NZGGghqxDza2gx8MALw2a9vBq28j26cr209LfR2tdGa/8RDvQfITPGmq2GWP2wGePyVBOr4ytKXXoVwBw4rYTr2G7c4y8gRgxnqqKTW8l07iXrF0qH/LycWiMWCpkQQomX5eKazmhH5FBUlFNzznV4oTz9N4AoEkMLfE9t10Km0WimmfkhZLk+yPSAlOT8PAcH2mnta6OlXw0Rnh5jzVaNnSgpDrkmeRHxMdZszSgyIHq6FffYbmLtO4l0t5XuHi46uY10w7bhopM89KHhisvDmFEYOD281ituueXn6qyIGjqMJsc3bkyF3IBKsS9GmGq7RqPRTDNzWsiklJwYPMH+zj20nt1HS99hDg924Jeps2UJi0sTDcpFGDoJ650lUw7RvVBEIY3b8byq3XVs9+iik5EEmYbXkGnYRmbVluGikyUklikBD9d9RYG4lyOeWI7pLh19/JBxw0kNnzMjRBMqub7410v6artGo9FMM3NKyPrz/bR2t9La3cr+rv0c6D5A/xiGjBXO0hLRUmu2ZiK5Y2xeaO/h+3tPcqY/y9Kkw3+71GSL30KsfSfOyb2IEaka+ZpG1etqvJpcXfP5e0pXvpPIri8TL0DMdLC9nBpe3bwD2p6E574GfcehphGu/W248h1TM25MlmvuhJ/eo1yJQwhTbZ+LjBOrpdFoqs+sFTIv8Gjra6Olq4WWblXZeKwFonErxprk6qLFxhdRM3LIrcK80N7DN39xiCs4xna/latO76ex81TJMdKwyNavI914NZnGbXjJ5RO6tm3YJCyX2JqbsKOLQ8E6odLlN/+GOuhn94DpQKxO9doe/bSaA6vEH+CVW1Rplny/MtsIQ32/crQBZdbT+hO1lMCIqEXe/Z3qeyZf2FOj0cwMs8q1eNmGy+RtX7yNlu4WDvYcJB/kRx1jCIOmVBPNtc2srV1L8+JmVpkxjFky/2LkBnCOP8ehZ/6Ddbl9JGVpykefiGNc8lolXis3ISOxMa5UiikMYpZLwoqNX54lEoMH3g8DpyFaVDQzn4ZkPez496k81uS4/+bRC6Iref/pZD49i6bSaNdihZhVPbKOgQ6+d/B7JduWOEtoXtw8LFyXLboMxxqxMDdT3sxRKazejtAevwun8xWE9FlWtP+ouZzn7ct5zr6cvd5yPn/9xHom53UcDmGYynUYTSmnYN+x8hFRUyhGOSXGiqiq1P2nk/n0LBrNPGVWCZkhDNYtWVfS21pazrRQbQIPp/MVZdRo343dVzrkKQ2bvdYlPGOs5eXolZw11bqznOdTmzr/wumhfMNRpVGKGco7dMJFy8WMFRE1hWKUU6La959O5tOzaDTzlFklZGsWreFz13+u2s0oiyo6uaeo6ORgyX7PrSXTsJV04zayKzZx6GSWHz59BEsKIlKS9wM8X/L29eXnwcZMlx+JFT2XNj+WGWSsiKgpFKOcEtW+/3Qyn55Fo5mnzKo5sikne2S6Ids3vY2RErv3GG77TmLHdhE9tb9s0ckh8covuVSZGooYci2e7c+yJOnw9vXLuarxXCpIxLCJ27HR6fIjGSqV4tRM3DY/jcUop0SV7z/pWKnxnInV/llq5ip6jqxCaCErxi/gdO4l1r4b99gu7P6TJbsDM0J25SZVMXnVVvz46KKT58M0TBKWEq+IeZ7lALYblkpJqDVgmgkx6WKYxc7EEQU/tWBpLgAtZBViVg0tVgMj04Pb8awaMjz+HEah1GXoxZYWDRluLFt08nyYwsC1XBKWi1Mu47CkQQZEa9Tc1/mETlOWSRfDfOre8oVAn7pXC5lGMwdYeEImJXZ3W5ggv4vo6dYRRScF+aVrVK+rYRv5xRdPaRGxIQxcM0rcUgG9500Qsd3QuJGozKLlecyki2FqZ6JGM6dZEEImvDzOyZdCl+EurMHSYpiB5ZBZuUnV7mp4DYFbO8aVznMfIXDMKIlQvM5bj8wwlWVe976mlUkXw9TORI1mTjNvhcxMd4UhvLtwTjyP4ZV+Gvfiy0g3blNDhss3XJCQTNhxCOfS5qPJ0bZ5zbQw6WKY2pmo0cxp5o+QSUmk65ByGbbvGlV0UgqDXF0zmQYlXoVFqy9oCG84JspysY0J/BhtJyxUqY0bM831r/0od8HEXYtrbwT+XDsTNZo5ypx3LbqHnyDW8gjukaew0iOKTtoxMqu2hC7D1xA4qQtqn2VYqjTKRByHEBo3UurLqkAFaY1GM5vQk90VYs73yGp2fRWnY8/w94XkCiVcjdvI1q+DifSWxmEo4zA+EcfhEEO9r2hSGzc0Go1mhpnzQpa+7I0Q+KTDnpdX03DB1zSEQcx0iFnuxByHcM64EU3q3pdGo9FUkDkvZH1bbqfvipsveEG0EAI3DOiNjRfQW3qSNm5oNBpNlZnzQnahOGZUiddEHIdD2E4oXklt3NBoNJoqM6NCJoRoBL4O1AMSuE9Kee9M3nMiTDjjsJi5tuZLVzXWaDQLhJnukXnA/5RS7hFCJIFnhRA/kVK+MsP3HYVt2MQtNXRoGxMUovFKpcxmdFVjjUazgJhRIZNSngBOhP/uF0LsA1YBFREyy7CGC1OOW1V5JKYdlkoJC1XONXR2oEajWUBU7K+0EKIJ2Aw8M2L7HcAdAA2NF+44nLJ4CaEWKzsple4wl9HZgRqNZgFRESETQiSAfwE+LqUssRdKKe8D7gO1IHoq1zeFQdxOTF68QFnlhxYtzxfjhs4O1Gg0C4gZFzIhhI0SsW9JKR+cxusSs2LE7TgxKwGZnsmcPH96X+XQ2YEajWYBMdOuRQF8BdgnpfzL6bimYzkk7AQxO3YuXT6fntjJpqWqLEdTyoU4X9HZgRqNZgEx0z2y64DbgZeEEM+H2+6SUv5gMheJmBHidpy4HceabOTUsPOwpnSobb6z9kYtXBqNZkEw067FnzPF4EzLsIjbcRJ2Ansq67YM81zvay46DzUajUYzIWbdX/hEJEHCTuBYztQuEImF5o3E9DZMo9FoNLOSWSVkpjBZ6i6d/InCALd27qRuaDQajWbamFVCNmVii6vdAo1Go9FUiXmycEqj0Wg0CxUtZBqNRqOZ02gh02g0Gs2cRguZRqPRaOY0Wsg0Go1GM6fRQqbRaDSaOY0WMo1Go9HMabSQaTQajWZOo4VMo9FoNHMaLWQajUajmdNoIdNoNBrNnEYLmUaj0WjmNFrINBqNRjOnEVLKardhGCHEaeDIDFx6KXBmBq47F1jIzw4L+/n1s1eXM1LKm6rchgXBrBKymUIIsVtKubXa7agGC/nZYWE/v372hfnsCxE9tKjRaDSaOY0WMo1Go9HMaRaKkN1X7QZUkYX87LCwn18/u2ZBsCDmyDQajUYzf1koPTKNRqPRzFO0kGk0Go1mTjPvhUwIYQohnhNC/Hu121JphBBtQoiXhBDPCyF2V7s9lUQIsUgI8YAQYr8QYp8Q4tpqt6lSCCGaw/d86KtPCPHxarerUgghfkcI8bIQYq8Q4ttCCKfabdLMLPN+jkwI8bvAViAlpby52u2pJEKINmCrlLLaC0MrjhDia8ATUsq/F0JEgJiUsqfa7ao0QggT6ABeK6WcibCBWYUQYhXwc+BKKWVGCPFd4AdSyvur2zLNTDKve2RCiAbg7cDfV7stmsohhKgBbgC+AiClzC9EEQt5E3BwIYhYERbgCiEsIAYcr3J7NDPMvBYy4P8CnwSCajekSkjgx0KIZ4UQd1S7MRXkYuA08A/hsPLfCyHi1W5UlXgv8O1qN6JSSCk7gD8HjgIngF4p5Y+r2yrNTDNvhUwIcTNwSkr5bLXbUkVeL6XcArwNuFMIcUO1G1QhLGAL8EUp5WZgEPj96jap8oRDqtuBf652WyqFEKIW+BXUh5mVQFwI8evVbZVmppm3QgZcB2wP54m+A7xRCPHN6japsoSfTpFSngIeAq6ubosqxjHgmJTymfD7B1DCttB4G7BHStlZ7YZUkDcDh6WUp6WUBeBB4HVVbpNmhpm3Qial/AMpZYOUsgk1vPKYlHLBfDITQsSFEMmhfwNvAfZWt1WVQUp5EmgXQjSHm94EvFLFJlWL21hAw4ohR4FrhBAxIYRAvff7qtwmzQxjVbsBmhmjHnhI/V/GAv5RSvlIdZtUUX4b+FY4vHYI+M0qt6eihB9ebgQ+VO22VBIp5TNCiAeAPYAHPIeOq5r3zHv7vUaj0WjmN/N2aFGj0Wg0CwMtZBqNRqOZ02gh02g0Gs2cRguZRqPRaOY0Wsg0Go1GM6fRQqbRaDSaOY0WMs2cQQjxhvHK8Qghdggh/t8M3HeHEGJl0fdtQoil030fjUYzNbSQaTTnZwcqt0+j0cxCtJBpppUwGuv7QogXwsKG7xFCvEYI8dMwhf9HQogV4bGPCyHuDYs/7hVCXB1uv1oI8Yswuf6poqipybSjTgjxL0KIXeHXdeH2PxJCfDW89yEhxEeLzvm0EKJFCPHzsCDjJ4QQt6Lq2X0rbKcbHv7bQog9YeHSy8dpR0II8Q/hcS8KId4Vbh8QQnw+LAD5aPjMQ23aPtnn1WgWMlrINNPNTcBxKeVVUsr1wCPAXwO3SilfA3wV+JOi42NSyk3Ab4X7APYD14fJ9X8I3D2FdtwL/JWUchvwLkpr0l0OvBUVovwZIYQthBg67ipU2O5WACnlA8Bu4NeklJuklJnwGmfCygJfBD4xTjs+jSolskFKuRF4LNweR+V/rgP6gc+iIqXeCfzxFJ5Xo1mw6KxFzXTzEvAXQoh7gH8HuoH1wE/C3EcTVSdqiG8DSCl/JoRICSEWAUnga0KINaiaavYU2vFm4MrwngApIUQi/Pf3pZQ5ICeEOIXKpbwO+FcpZRbICiH+7TzXfzB8fRa45TzteO/QN1LK7vCfeZTIg/qZ5aSUBSHES0DT+R5Oo9GcQwuZZlqRUrYKIbYAv4zqZTwGvCylvHasU8p8/3+A/5RSvlMI0QQ8PoWmGMA1oTANEwpbrmiTz9T+HwxdY6rnF+S5oNNg6HpSyiCsbKzRaCaIHlrUTCuhuy8tpfwm8HngtUCdEOLacL8thFhXdMp7wu2vRw3B9QI1QEe4f8cUm/JjVAL+ULs2nef4J4F3CCGcsOd2c9G+flQvcSr8BLizqB21U7yORqMZAy1kmulmA7BTCPE88BnUHNetwD1CiBeA5yktdJgVQjwHfAl4f7jtz4A/DbdPtXfyUWBraLB4BfjweAdLKXcBDwMvAj9EDff1hrvvB740wuwxUT4L1IZmlheAX5rk+RqN5jzoMi6aqiGEeBz4hJRyd7XbAsphKKUcEELEgJ8Bd0gp91S7XRqNZnz0WLxGc477hBBXAg7wNS1iGs3cQPfINHMOIcRvAh8bsflJKeWd5Y6vBLOxTRrNQkELmUaj0WjmNNrsodFoNJo5jRYyjUaj0cxptJBpNBqNZk6jhUyj0Wg0c5r/D47P9ZrgfI+fAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 444.75x360 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "sns.lmplot(x=\"sepal_length_cm\", y=\"sepal_width_cm\", hue=\"species\", data=df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grouped_model = GroupedPipeline(\n",
+    "    groupby=\"species\",\n",
+    "    pipeline=simple_model\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "GroupedPipeline(errors='raise', groupby='species',\n",
+       "        pipeline=Pipeline(memory=None,\n",
+       "     steps=[('features', PandasValueSelector(columns='sepal_length_cm')), ('lr', LinearRegression(copy_X=True, fit_intercept=True, n_jobs=None,\n",
+       "         normalize=False))]))"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "grouped_model.fit(df, df[\"sepal_width_cm\"])\n",
+    "\n",
+    "# Specifying target by column name is also supported:\n",
+    "grouped_model.fit(df, \"sepal_width_cm\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MSE = 0.07119979049915942, MAE = 0.20655162210804365\n"
+     ]
+    }
+   ],
+   "source": [
+    "y_pred, y = grouped_model.predict(df), df[\"sepal_width_cm\"]\n",
+    "print(f\"MSE = {mse(y, y_pred)}, MAE = {mae(y, y_pred)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "setosa: intercept: -0.57, slope: 0.80\n",
+      "versicolor: intercept: 0.87, slope: 0.32\n",
+      "virginica: intercept: 1.45, slope: 0.23\n"
+     ]
+    }
+   ],
+   "source": [
+    "for group, pipe in grouped_model.pipelines_.items():\n",
+    "    lr = pipe.named_steps['lr']\n",
+    "    print(f\"{group}: intercept: {lr.intercept_:.2f}, slope: {lr.coef_[0]:.2f}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -25,6 +25,7 @@
    examples/MNIST
    examples/SolarGenerationTimeSeries_Part1
    examples/SolarGenerationTimeSeries_Part2
+   examples/GroupedPipeline
 
 .. toctree::
    :maxdepth: 1

--- a/tests/test_data/test_datasets.py
+++ b/tests/test_data/test_datasets.py
@@ -1,0 +1,9 @@
+from timeserio.data import datasets
+
+
+def test_load_iris_df():
+    df = datasets.load_iris_df()
+
+    assert "species" in df
+    assert "sepal_width_cm" in df
+    assert len(df)

--- a/tests/test_pipeline/test_utils.py
+++ b/tests/test_pipeline/test_utils.py
@@ -1,0 +1,26 @@
+import pytest
+
+import pandas as pd
+
+from timeserio.pipeline.pipeline import _y_as_string
+
+
+@pytest.fixture
+def df():
+    df = pd.DataFrame({
+        "x": [1, 2, 3],
+        "y": [1, 4, 9],
+    })
+    return df
+
+
+def test_fit_decorator(df):
+    """Test we can pass the target column by name."""
+    @_y_as_string
+    def fit(df, y):
+        return df["x"] + y
+
+    fit1 = fit(df, df["y"])
+    fit2 = fit(df, "y")
+
+    pd.testing.assert_series_equal(fit1, fit2)

--- a/tests/test_pipeline/test_utils.py
+++ b/tests/test_pipeline/test_utils.py
@@ -2,7 +2,7 @@ import pytest
 
 import pandas as pd
 
-from timeserio.pipeline.pipeline import _y_as_string
+from timeserio.pipeline.pipeline import _parse_df_y
 
 
 @pytest.fixture
@@ -16,8 +16,8 @@ def df():
 
 def test_fit_decorator(df):
     """Test we can pass the target column by name."""
-    @_y_as_string
     def fit(df, y):
+        df, y = _parse_df_y(df, y)
         return df["x"] + y
 
     fit1 = fit(df, df["y"])

--- a/timeserio/data/datasets.py
+++ b/timeserio/data/datasets.py
@@ -1,0 +1,19 @@
+import pandas as pd
+import sklearn.datasets
+
+
+def load_iris_df():
+    """Return Iris dataset as a DataFrame."""
+    iris = sklearn.datasets.load_iris()
+    feature_names = [
+        s.replace("(cm)", "cm").strip().replace(" ", "_")
+        for s in iris['feature_names']
+    ]
+    df = pd.DataFrame(
+        data=iris['data'],
+        columns=feature_names
+    )
+    target_names = iris['target_names']
+    targets = target_names[iris['target']]
+    df["species"] = targets
+    return df

--- a/timeserio/pipeline/pipeline.py
+++ b/timeserio/pipeline/pipeline.py
@@ -1,10 +1,23 @@
+import functools
+
 import numpy as np
 import pandas as pd
+
 import sklearn.pipeline
 from sklearn.base import BaseEstimator, TransformerMixin, clone
 from sklearn.utils.validation import check_is_fitted
 
 from .. import ini
+
+
+def _y_as_string(func):
+    """Allow func(X, y) to be called as func(df, col_name)."""
+    @functools.wraps(func)
+    def decorated(X, y, **kwargs):
+        if isinstance(X, pd.DataFrame) and isinstance(y, str):
+            X, y = X, X[y]
+        return func(X, y, **kwargs)
+    return decorated
 
 
 class FeatureUnion(sklearn.pipeline.FeatureUnion):


### PR DESCRIPTION
Before this change, calling `.fit(df, y)` (supervised learning per group) was not supported. After this change, `.fit(df, y)` as well as `.fit(df, target_column_name)` is supported.

Add GroupedPipeline example notebook
