### PR TITLE
Fix GroupedPipeline _iter_groups

### DIFF
--- a/tests/test_pipeline/test_grouped_pipeline.py
+++ b/tests/test_pipeline/test_grouped_pipeline.py
@@ -188,3 +188,17 @@ def test_all_groups_missing_raises(input_df, errors):
     with pytest.raises(KeyError,
                        message='All keys missing in fitted pipelines'):
         gp.transform(transform_df)
+
+
+@pytest.mark.parametrize(
+    "index", [[1, 2, 3, 4], pd.date_range("2019-01-01", periods=4)]
+)
+def test_iter_groups_non_consecutive_index(index):
+    group = [1] * 2 + [2] * (len(index) - 2)
+    value = np.random.random(len(index))
+    input_df = pd.DataFrame(
+        [group, value], index=["group", "value"], columns=index
+    ).T
+    gp = GroupedPipeline(groupby=["group"], pipeline=None)
+    for key, sub_df, _ in gp._iter_groups(input_df):
+        assert (sub_df["group"] == key).all()

--- a/timeserio/pipeline/pipeline.py
+++ b/timeserio/pipeline/pipeline.py
@@ -124,7 +124,7 @@ class GroupedPipeline(BaseEstimator, TransformerMixin):
 
     def _iter_groups(self, df, y=None):
         """Iterate over groups of `df`, and, if provided, matching labels."""
-        groups = df.groupby(self.groupby).groups
+        groups = df.groupby(self.groupby).indices
         for key, sub_idx in groups.items():
             sub_df = df.iloc[sub_idx]
             sub_y = y[sub_idx] if y is not None else None


### PR DESCRIPTION
Before, _iter_groups (which essentially does a GroupBy, splitting the dataframe) was using
`GroupBy.groups` then `.iloc`. However, `GroupBy.groups` returns actual labels (ie for use with `.loc`) so this would fail when the index wasn't 0-indexed consecutive integers.

This PR adds a test & makes the small fix.