### PR TITLE
Add PandasTimeSeriesSplit

### DIFF
--- a/tests/test_model_selection/test_time_series_split.py
+++ b/tests/test_model_selection/test_time_series_split.py
@@ -1,0 +1,110 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from timeserio.model_selection import PandasTimeSeriesSplit
+
+
+def input_df(teams, index_offset=0, num_days=12):
+    days = pd.date_range("2019-01-01", periods=num_days).tolist()
+    df = pd.DataFrame(
+        {
+            "team": sum([[team] * num_days for team in teams], []),
+            "val": np.concatenate(
+                [np.random.random(num_days) for _ in range(len(teams))]
+            ),
+            "date": days * len(teams),
+        }
+    )
+    df.index += index_offset
+    return df
+
+
+@pytest.mark.parametrize(
+    "df",
+    [
+        input_df(["A"]),
+        input_df(["A", "B"]),
+        input_df(["A", "B", "C"]),
+        input_df(["A"], index_offset=1),
+        input_df(["A", "B"], index_offset=1),
+    ],
+)
+def test_pandas_time_series_split(df):
+    splitter = PandasTimeSeriesSplit(
+        groupby="team", datetime_col="date", n_splits=3
+    )
+
+    count = 0
+    for X_idx, y_idx in splitter.split(df):
+        count += 1
+        X, y = df.iloc[X_idx], df.iloc[y_idx]
+
+        for team in df.team.unique():
+            X_team, y_team = X[X.team == team], y[y.team == team]
+            min_train, max_train = X_team["date"].min(), X_team["date"].max()
+            min_test, max_test = y_team["date"].min(), y_team["date"].max()
+
+            assert (min_test - max_train).days == 1
+            assert (max_train - min_train).days == count * 3 - 1
+            assert (max_test - min_test).days == 3 - 1
+
+    assert count == 3
+
+
+def test_raises_nonunique():
+    df = input_df(teams=["A"])
+    df.index = [1] * len(df)
+
+    splitter = PandasTimeSeriesSplit(
+        groupby="team", datetime_col="date", n_splits=3
+    )
+
+    with pytest.raises(ValueError):
+        for X_idx, y_idx in splitter.split(df):
+            pass
+
+
+def test_raises_non_ascending():
+    df = input_df(teams=["A"])
+    df = df.sort_values("date", ascending=False)
+
+    splitter = PandasTimeSeriesSplit(
+        groupby="team", datetime_col="date", n_splits=3
+    )
+
+    with pytest.raises(ValueError):
+        for X_idx, y_idx in splitter.split(df):
+            pass
+
+
+def test_different_series_lengths():
+    df = pd.concat(
+        [
+            input_df(teams=["A"], num_days=15),
+            input_df(teams=["B"], num_days=30),
+        ],
+        ignore_index="ignore",
+    )
+
+    split_lens = {"A": 3, "B": 6}
+
+    splitter = PandasTimeSeriesSplit(
+        groupby="team", datetime_col="date", n_splits=4
+    )
+
+    count = 0
+    for X_idx, y_idx in splitter.split(df):
+        count += 1
+        X, y = df.iloc[X_idx], df.iloc[y_idx]
+
+        for team in df.team.unique():
+            X_team, y_team = X[X.team == team], y[y.team == team]
+            min_train, max_train = X_team["date"].min(), X_team["date"].max()
+            min_test, max_test = y_team["date"].min(), y_team["date"].max()
+
+            assert (min_test - max_train).days == 1
+            assert (max_train - min_train).days == count * split_lens[team] - 1
+            assert (max_test - min_test).days == split_lens[team] - 1
+
+    assert count == 4

--- a/timeserio/model_selection/__init__.py
+++ b/timeserio/model_selection/__init__.py
@@ -1,0 +1,1 @@
+from .time_series_split import PandasTimeSeriesSplit  # noqa

--- a/timeserio/model_selection/time_series_split.py
+++ b/timeserio/model_selection/time_series_split.py
@@ -1,0 +1,84 @@
+from typing import List, Union
+
+import numpy as np
+from sklearn.model_selection import TimeSeriesSplit
+from sklearn.model_selection._split import _BaseKFold
+
+
+class PandasTimeSeriesSplit(_BaseKFold):
+    """Apply a sklearn TimeSeriesSplit to multiple timeseries in a single DF.
+
+    The dataframe should be ordered by date ascending for each time series, and
+    the index should be unique.
+
+    Parameters:
+        groupby : string or array of strings
+            The column name(s) to group the input dataframe by - each group
+            should hold a monotonically increasing time series.
+
+        datetime_col : string
+            The column name of the datetime column - used to validate that the
+            dataframe is groups of time series.
+
+        n_splits : int, default = 3
+            Number of splits. Must be at least 2.
+
+        max_train_size : int, optional
+            Maximum size for a single training set.
+
+    """
+
+    def __init__(
+        self,
+        groupby: Union[str, List[str]],
+        datetime_col: str,
+        n_splits: int = 3,
+        max_train_size: int = None,
+    ):
+        self.groupby = groupby
+        self.datetime_col = datetime_col
+        self.n_splits = n_splits
+        self.max_train_size = max_train_size
+
+    def split(self, df, y=None, groups=None):
+        self._validate_df(df)
+        groups = df.groupby(self.groupby).indices
+        splits = {}
+        while True:
+            X_idxs, y_idxs = [], []
+            for key, sub_idx in groups.items():
+                sub_df = df.iloc[sub_idx]
+                sub_y = y[sub_idx] if y is not None else None
+
+                if key not in splits:
+                    splitter = TimeSeriesSplit(
+                        self.n_splits, self.max_train_size
+                    )
+                    splits[key] = splitter.split(sub_df, sub_y)
+
+                try:
+                    X_idx, y_idx = next(splits[key])
+                    X_idx = np.array(
+                        [df.index.get_loc(i) for i in sub_df.iloc[X_idx].index]
+                    )
+                    y_idx = np.array(
+                        [df.index.get_loc(i) for i in sub_df.iloc[y_idx].index]
+                    )
+                    X_idxs.append(X_idx)
+                    y_idxs.append(y_idx)
+                except StopIteration:
+                    pass
+
+            if len(X_idxs) == 0:
+                break
+
+            yield np.concatenate(X_idxs), np.concatenate(y_idxs)
+
+    def _validate_df(self, df):
+        if df.index.duplicated().any():
+            raise ValueError("Dataframe has non-unique index.")
+        shift_date = df.groupby(self.groupby)[self.datetime_col].shift()
+        if (shift_date >= df[self.datetime_col]).any():
+            raise ValueError(
+                "Dataframe not in ascending order for each time series."
+            )


### PR DESCRIPTION
to extend the sklearn TimeSeriesSplit to cases where there are several time series - eg, a time
series for each team.

It uses a list comprehension `.loc` in the middle which I don't really like, but I couldn't think of a pure-pandas way to turn index labels -> index locations.