### PR TITLE
Add a `refit` option to LagFeaturizer to allow pre-fitting lags

### DIFF
--- a/tests/test_preprocessing/test_datetime_lag.py
+++ b/tests/test_preprocessing/test_datetime_lag.py
@@ -32,6 +32,31 @@ def test_fit_single_lag(df):
     npt.assert_equal(values_lagged[:1], np.nan)
 
 
+def test_dont_refit(df):
+    feat = LagFeaturizer(
+        datetime_column=ini.Columns.datetime,
+        columns=ini.Columns.target,
+        lags=DEF_FREQ,
+        refit=False,
+    )
+    feat.fit(df)
+    second = df.copy()
+    second[ini.Columns.target] *= 2
+    out = feat.fit_transform(second)
+
+    first_values = df[ini.Columns.target].values
+    second_values = second[ini.Columns.target].values
+    values_transformed = out[ini.Columns.target].values
+    values_lagged = out[f"{ini.Columns.target}_{DEF_FREQ}"].values
+
+    # The target column is the same as the dataframe passed to fit_transform
+    npt.assert_equal(second_values, values_transformed)
+    # But the lagged values correspond to first dataframe
+    # since the second fit is ignored
+    npt.assert_equal(first_values[:-1], values_lagged[1:])
+    npt.assert_equal(values_lagged[:1], np.nan)
+
+
 def test_fit_multiple_lags(df):
     feat = LagFeaturizer(
         datetime_column=ini.Columns.datetime,

--- a/timeserio/preprocessing/datetime.py
+++ b/timeserio/preprocessing/datetime.py
@@ -229,6 +229,9 @@ class LagFeaturizer(BaseEstimator, TransformerMixin, CallableMixin):
         lags: List[DateOffset, tseries.offsets, timedelta, or str]
             List of lags to apply.
             See pandas.DataFrame.shift
+        refit: bool, default True
+            If set to False, a fitted LagFeaturizer will not be refitted
+            on subsequent calls to `fit()`
         duplicate_agg: str, default 'raise'
             Aggregation functions to apply to values for duplicate datetimes.
             By default, an error is raised if duplicates
@@ -244,14 +247,18 @@ class LagFeaturizer(BaseEstimator, TransformerMixin, CallableMixin):
         datetime_column,
         columns,
         lags,
+        refit=True,
         duplicate_agg='raise'
     ):
         self.datetime_column = datetime_column
         self.columns = columns
         self.lags = lags
+        self.refit = refit
         self.duplicate_agg = duplicate_agg
 
     def fit(self, df, y=None, **fit_params):
+        if hasattr(self, 'df_') and not self.refit:
+            return self
         columns = _as_list_of_str(self.columns)
         self.df_ = df.set_index(self.datetime_column)[columns]
         if self.duplicate_agg == 'raise':


### PR DESCRIPTION
Before this change, a `LagFeaturizer` would always respect causality and avoid data leakage (good). This means however that on-the-fly validation with "safe" features such as historic temperature lags could not be performed. After this change, the LagFeaturizer can be explicitly pre-fitted on all available data for the feature in question, and set to "frozen" using e.g. `set_params(refit=False)`. This advanced use case requires extra care, but the change is introduced without changing default behaviour.