### PR TITLE
Add "day" to supported pandas datetime attributes

### DIFF
--- a/timeserio/preprocessing/datetime.py
+++ b/timeserio/preprocessing/datetime.py
@@ -129,6 +129,7 @@ SUPPORTED_DATETIME_ATTRS = [
     'time',
     'hour',
     'month',
+    'day',
     'dayofweek',
     'dayofyear',
     'weekday_name',


### PR DESCRIPTION
The pandas "day" attribute refers to the day of the month.