### PR TITLE
Add `country` keyword argument for is_holiday

### DIFF
--- a/tests/test_preprocessing/test_datetime_features.py
+++ b/tests/test_preprocessing/test_datetime_features.py
@@ -64,6 +64,17 @@ def test_get_is_holiday_from_series():
     pdt.assert_series_equal(is_holiday, expected)
 
 
+@pytest.mark.parametrize(
+    "country, expected",
+    [("England", [1, 0, 0, 1]), ("Scotland", [1, 1, 1, 0])]
+)
+def test_get_is_holiday_from_series_with_country(country, expected):
+    dates = ["2020-01-01", "2020-01-02", "2020-08-03", "2020-08-31"]
+    series = pd.to_datetime(pd.Series(dates))
+    is_holiday = get_is_holiday_from_series(series, country=country)
+    pdt.assert_series_equal(is_holiday, pd.Series(expected))
+
+
 def test_get_zero_indexed_month_from_series():
     series = pd.Series(
         pd.date_range(start='2000-01-01', freq='1M', periods=12)

--- a/timeserio/preprocessing/datetime.py
+++ b/timeserio/preprocessing/datetime.py
@@ -5,7 +5,7 @@ from sklearn.utils.validation import check_is_fitted
 from .. import ini
 from .utils import _as_list_of_str, CallableMixin
 
-from holidays import UnitedKingdom as HolidayCalender
+import holidays
 
 DAYS_IN_YEAR = 365
 HOURS_IN_DAY = 24
@@ -48,14 +48,18 @@ def get_fractional_year_from_series(series: pd.Series) -> pd.Series:
     return (series.dt.dayofyear - 1) / 365
 
 
-def get_is_holiday_from_series(series: pd.Series) -> pd.Series:
-    """Return 1 if day is a UK public holiday.
+def get_is_holiday_from_series(
+    series: pd.Series, country: str = "UnitedKingdom"
+) -> pd.Series:
+    """Return 1 if day is a public holiday.
 
-    FixMe: may require region information (England/Wales/Scotland)
-    FixMe: maybe move to geo-related features
+    By default, uses UK holidays, but can specify a country by string name in
+    `country` arg. See `holidays.list_supported_countries()` for list of
+    supported countries.
     """
     years = series.dt.year.unique()
-    return series.dt.date.isin(HolidayCalender(years=years)).astype(int)
+    holiday_dates = holidays.CountryHoliday(country, years=years)
+    return series.dt.date.isin(holiday_dates).astype(int)
 
 
 def get_zero_indexed_month_from_series(series: pd.Series) -> pd.Series:


### PR DESCRIPTION
Specify which country's holidays you want:
```
PandasDateTimeFeaturizer(
    column=date_col, attributes=["is_holiday"], kwargs=dict(country="England")
)
```
Default remains as before, so not setting `kwargs` returns UK holidays.