### PR TITLE
Add rolling mean Pandas featurizer.

### DIFF
--- a/tests/test_preprocessing/test_datetime_lag.py
+++ b/tests/test_preprocessing/test_datetime_lag.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 import timeserio.ini as ini
 from timeserio.data.mock import mock_raw_data, DEF_FREQ
-from timeserio.preprocessing import LagFeaturizer
+from timeserio.preprocessing import LagFeaturizer, RollingMeanFeaturizer
 
 
 @pytest.fixture
@@ -138,3 +138,20 @@ def test_fit_with_duplicates_with_agg(df):
 
     assert len(feat.df_) == len(df)
     assert len(df_test_transformed) == len(df_test)
+
+
+def test_fit_rolling_mean_single_window(df):
+    window = "6H"
+    feat = RollingMeanFeaturizer(
+        datetime_column=ini.Columns.datetime,
+        columns=ini.Columns.target,
+        windows=[window]
+    )
+    df2 = feat.fit_transform(df)
+    values = df[ini.Columns.target].values
+    values_transformed = df2[ini.Columns.target].values
+    values_rolled = df2[f"{ini.Columns.target}_{window}"].values
+
+    npt.assert_equal(values, values_transformed)
+    npt.assert_equal(values[0], values_rolled[0])
+    npt.assert_almost_equal(values[:12].mean(), values_rolled[11])

--- a/timeserio/preprocessing/__init__.py
+++ b/timeserio/preprocessing/__init__.py
@@ -5,5 +5,5 @@ from .encoding import (FeatureIndexEncoder,  # noqa
 from .pandas import (PandasColumnSelector,  # noqa
                      PandasValueSelector,
                      PandasSequenceSplitter)
-from .datetime import PandasDateTimeFeaturizer, LagFeaturizer  # noqa
+from .datetime import PandasDateTimeFeaturizer, LagFeaturizer, RollingMeanFeaturizer  # noqa
 from .aggregate import AggregateFeaturizer  # noqa

--- a/timeserio/preprocessing/datetime.py
+++ b/timeserio/preprocessing/datetime.py
@@ -229,8 +229,8 @@ class _BaseLagFeaturizer(BaseEstimator, TransformerMixin, CallableMixin):
         datetime_column,
         columns,
         lags,
-        refit = True,
-        duplicate_agg = "raise"
+        refit=True,
+        duplicate_agg="raise"
     ):
         self.datetime_column = datetime_column
         self.columns = columns

--- a/timeserio/preprocessing/datetime.py
+++ b/timeserio/preprocessing/datetime.py
@@ -376,6 +376,14 @@ class RollingMeanFeaturizer(_BaseLagFeaturizer):
         self.win_type = win_type
         self.closed = closed
 
+    @property
+    def windows(self):
+        return self.lags
+
+    @windows.setter
+    def windows(self, windows):
+        self.lags = windows
+
     def _lag_df(self, lag):
         return self.df_.rolling(
             window=lag,

--- a/timeserio/preprocessing/datetime.py
+++ b/timeserio/preprocessing/datetime.py
@@ -221,8 +221,8 @@ class _BaseLagFeaturizer(BaseEstimator, TransformerMixin, CallableMixin):
     datetime_column: str
     columns: Union[str, List[str]]
     lags: List
-    refit: bool
-    duplicate_agg: str
+    refit: bool = True
+    duplicate_agg: str = "raise"
 
     def __init__(
         self,


### PR DESCRIPTION
Previous to the commit, the LagFeaturizer class only dealt with shifted values. I've used the majority of the code to turn this into a base class that can be used to create numerous types of lagged features and have added a rolling mean featurizer.