### PR TITLE
Fix set_params on entire subpipelines

### DIFF
--- a/tests/test_pipeline/test_multipipeline.py
+++ b/tests/test_pipeline/test_multipipeline.py
@@ -63,7 +63,11 @@ def test_get_attr(multipipeline):
 
 
 def test_get_item(multipipeline):
-    assert multipipeline['poly'] is multipipeline.poly
+    assert multipipeline["poly"] is multipipeline.poly
+    # Set params overwrites the attribute in this way, so it needs to pass the
+    # change on to the underlying dict
+    multipipeline.poly = "overwritten"
+    assert multipipeline["poly"] is multipipeline.poly
 
 
 def test_pipeline_validation(multipipeline_validation):

--- a/timeserio/pipeline/multipipeline.py
+++ b/timeserio/pipeline/multipipeline.py
@@ -18,6 +18,12 @@ class MultiPipeline(BaseEstimator):
         """Get parameter names for the estimator."""
         return sorted(self.pipelines.keys())
 
+    def __setattr__(self, item, value):
+        if item != "pipelines" and item in self.pipelines:
+            self.pipelines[item] = value
+        else:
+            super().__setattr__(item, value)
+
     def __getattr__(self, item):
         if item in self.pipelines:
             return self.pipelines[item]


### PR DESCRIPTION
MultiPipeline uses `__getattr__` to expose subpipelines stored in the dict
`MutliPipeline.pipelines` as attributes, so sklearn can access them when
using `.get_params` and `.set_params`. However, `__getattr__` is only called
if the attribute isn't found in the `objects .__dict__` - so if a whole
pipeline is overwritten with `pipeline.set_params`, it silently creates a
new attribute that is accessed instead of the original subpipeline with
using `getattr`, but the original pipeline remains unchanged when
accessed via `pipeline.pipelines` (which is how it's called in
`.transform` or `.fit`).

In other words, using `.set_params` for an entire subpipeline causes
`.get_params` to show different parameters to what's being called in the
code.

This change adds a failing test &  a fix: implementing `__setattr__` so
that the attributes and pipelines are always in sync regardless of how
they are updated.