### PR TITLE
Speed up batch generation for tall data frames

### DIFF
--- a/timeserio/batches/single/row.py
+++ b/timeserio/batches/single/row.py
@@ -28,14 +28,13 @@ class RowBatchGenerator(BatchGenerator):
     def __getitem__(self, batch_idx):
         if not len(self):
             raise IndexError('Batch index out of range: Empty batch generator')
-        columns = self.columns
-        if not columns:
-            columns = self.df.columns
         batch_idx = batch_idx % len(self)
-        batch_df = self.df[columns].iloc[
+        batch_df = self.df.iloc[
             batch_idx * self._eff_batch_size:
             batch_idx * self._eff_batch_size +
             self._eff_batch_size
         ]
+        if self.columns:
+            batch_df = batch_df[self.columns]
 
         return batch_df


### PR DESCRIPTION
This can be literally a million times faster for large dataframes as the `.iloc` is zero-copy, even if we perform column sub-selection after iloc.

## Update
@ali-tny regarding wide dataframes, I have not managed to find an example where the new change is slower. e.g.:
```python
n_rows, n_cols = (10_000, 100_000)
n_selected_columns = 10_000
df = pd.DataFrame(np.ones((n_rows, n_cols)))

columns = np.random.choice(range(n_cols), n_selected_columns)

%time df[columns].iloc[:10]
%time df.iloc[:10][columns]
```
yields sth like
```
CPU times: user 1.84 s, sys: 5.21 s, total: 7.05 s
Wall time: 8.01 s
CPU times: user 4 ms, sys: 2.87 ms, total: 6.87 ms
Wall time: 6.49 ms
```