### PR TITLE
Add PandasIndexValueSelector

### DIFF
--- a/tests/test_preprocessing/test_pandas_feature_selector.py
+++ b/tests/test_preprocessing/test_pandas_feature_selector.py
@@ -5,7 +5,8 @@ import pytest
 import timeserio.ini as ini
 from timeserio.data.mock import mock_fit_data
 from timeserio.preprocessing import (
-    PandasColumnSelector, PandasValueSelector, PandasSequenceSplitter
+    PandasColumnSelector, PandasValueSelector,
+    PandasIndexValueSelector, PandasSequenceSplitter
 )
 
 
@@ -16,6 +17,11 @@ usage_column = ini.Columns.target
 @pytest.fixture
 def df(use_tensor_extension):
     return mock_fit_data(use_tensor_extension=use_tensor_extension)
+
+
+@pytest.fixture
+def indexed_df():
+    return mock_fit_data(index=True)
 
 
 @pytest.mark.parametrize(
@@ -56,6 +62,23 @@ def test_column_selector(df, columns, num_columns):
 def test_value_selector(df, columns, shape1):
     expected_shape = (len(df), shape1)
     subarray = PandasValueSelector(columns=columns).transform(df)
+    assert isinstance(subarray, np.ndarray)
+    assert subarray.shape == expected_shape
+
+
+@pytest.mark.parametrize(
+    'levels, shape1', [
+        (None, 0),
+        ([], 0),
+        (datetime_column, 1),
+        ([datetime_column], 1),
+        ([1, -1], 2),
+        ([datetime_column, 0], 2),
+    ]
+)
+def test_index_value_selector(indexed_df, levels, shape1):
+    expected_shape = (len(indexed_df), shape1)
+    subarray = PandasIndexValueSelector(levels=levels).transform(indexed_df)
     assert isinstance(subarray, np.ndarray)
     assert subarray.shape == expected_shape
 

--- a/timeserio/data/mock.py
+++ b/timeserio/data/mock.py
@@ -72,7 +72,8 @@ def mock_fit_data(
     ids=[0],
     embedding_dim=DEF_EMB_DIM,
     seq_length=DEF_SEQ_LENGTH,
-    use_tensor_extension=False
+    use_tensor_extension=False,
+    index=False
 ):
     """Create example fit data in the tall DataFrame format."""
     user_dfs = [
@@ -86,7 +87,9 @@ def mock_fit_data(
         ) for id in ids
     ]
     df = pd.concat(user_dfs, axis=0)
-    df.reset_index(inplace=True, drop=True)
+    df = df.reset_index(drop=True)
+    if index:
+        df = df.set_index([ini.Columns.datetime, ini.Columns.id])
     return df
 
 

--- a/timeserio/preprocessing/__init__.py
+++ b/timeserio/preprocessing/__init__.py
@@ -4,6 +4,7 @@ from .encoding import (FeatureIndexEncoder,  # noqa
                        StatelessTemporalOneHotEncoder)
 from .pandas import (PandasColumnSelector,  # noqa
                      PandasValueSelector,
+                     PandasIndexValueSelector,
                      PandasSequenceSplitter)
 from .datetime import PandasDateTimeFeaturizer, LagFeaturizer, RollingMeanFeaturizer  # noqa
 from .aggregate import AggregateFeaturizer  # noqa

--- a/timeserio/preprocessing/pandas.py
+++ b/timeserio/preprocessing/pandas.py
@@ -111,6 +111,31 @@ class PandasValueSelector(BaseEstimator, TransformerMixin):
         return {None}
 
 
+class PandasIndexValueSelector(BaseEstimator, TransformerMixin):
+    """Select index levels as feature cols, and return np.array."""
+
+    def __init__(self, levels=None):
+        self.levels = levels
+
+    def fit(self, df, y=None, **fit_params):
+        return self
+
+    def transform(self, df):
+        levels = self.levels or []
+        if isinstance(levels, str):
+            levels = [levels]
+        try:
+            iter(levels)
+        except TypeError:
+            levels = [levels]
+        blocks = [
+            df.index.get_level_values(level).values.reshape(-1, 1)
+            for level in levels
+        ]
+        subarray = np.hstack(blocks) if blocks else np.empty((len(df), 0))
+        return subarray
+
+
 class PandasSequenceSplitter(BaseEstimator, TransformerMixin):
     """Split sequence columns in two."""
 


### PR DESCRIPTION
Like PandasValueSelector, but allows selecting values from the index by integer level or level name.
Because sometimes it's more efficient to keep the index in the dataframe and batches without having to call reset_index() on each.