### PR TITLE
Fix allowed hyperparam introspection for TF2.2.0

### DIFF
--- a/tests/test_keras/test_multinetwork.py
+++ b/tests/test_keras/test_multinetwork.py
@@ -279,7 +279,7 @@ class TestSubClass:
 
     def test_fit_default(self, multinetwork):
         x = np.random.rand(13, 1)
-        y = np.random.rand(13, 1)
+        y = x * 2
         metrics0 = multinetwork.evaluate(x, y, model='forecaster')
         multinetwork.fit(x, y, model='forecaster', batch_size=100, epochs=1)
         metrics = multinetwork.evaluate(x, y, model='forecaster')
@@ -330,7 +330,7 @@ class TestSubClass:
     def test_evaluate(self, multinetwork):
         x = np.random.rand(13, 1)
         y = np.random.rand(13, 1)
-        num_epochs = 1
+        num_epochs = 2
         model = 'forecaster'
         multinetwork.fit(x, y, model=model, batch_size=100, epochs=num_epochs)
         mse, mae = multinetwork.evaluate(x, y, model=model)
@@ -338,7 +338,10 @@ class TestSubClass:
         assert mse >= 0
         assert mae >= 0
         assert history['loss'][0] >= mse
-        assert history['mean_absolute_error'][0] >= mae
+        if "mean_absolute_error" in history:
+            assert history['mean_absolute_error'][0] >= mae
+        else:
+            assert history['mae'][0] >= mae
 
     @pytest.mark.parametrize('batch_size', [1, 2, 2 ** 10])
     def test_evaluate_generator(self, multinetwork, batch_size):

--- a/tests/test_preprocessing/test_pandas_feature_selector.py
+++ b/tests/test_preprocessing/test_pandas_feature_selector.py
@@ -5,7 +5,8 @@ import pytest
 import timeserio.ini as ini
 from timeserio.data.mock import mock_fit_data
 from timeserio.preprocessing import (
-    PandasColumnSelector, PandasValueSelector, PandasSequenceSplitter
+    PandasColumnSelector, PandasValueSelector,
+    PandasIndexValueSelector, PandasSequenceSplitter
 )
 
 
@@ -16,6 +17,11 @@ usage_column = ini.Columns.target
 @pytest.fixture
 def df(use_tensor_extension):
     return mock_fit_data(use_tensor_extension=use_tensor_extension)
+
+
+@pytest.fixture
+def indexed_df():
+    return mock_fit_data(index=True)
 
 
 @pytest.mark.parametrize(
@@ -56,6 +62,23 @@ def test_column_selector(df, columns, num_columns):
 def test_value_selector(df, columns, shape1):
     expected_shape = (len(df), shape1)
     subarray = PandasValueSelector(columns=columns).transform(df)
+    assert isinstance(subarray, np.ndarray)
+    assert subarray.shape == expected_shape
+
+
+@pytest.mark.parametrize(
+    'levels, shape1', [
+        (None, 0),
+        ([], 0),
+        (datetime_column, 1),
+        ([datetime_column], 1),
+        ([1, -1], 2),
+        ([datetime_column, 0], 2),
+    ]
+)
+def test_index_value_selector(indexed_df, levels, shape1):
+    expected_shape = (len(indexed_df), shape1)
+    subarray = PandasIndexValueSelector(levels=levels).transform(indexed_df)
     assert isinstance(subarray, np.ndarray)
     assert subarray.shape == expected_shape
 

--- a/timeserio/data/mock.py
+++ b/timeserio/data/mock.py
@@ -72,7 +72,8 @@ def mock_fit_data(
     ids=[0],
     embedding_dim=DEF_EMB_DIM,
     seq_length=DEF_SEQ_LENGTH,
-    use_tensor_extension=False
+    use_tensor_extension=False,
+    index=False
 ):
     """Create example fit data in the tall DataFrame format."""
     user_dfs = [
@@ -86,7 +87,9 @@ def mock_fit_data(
         ) for id in ids
     ]
     df = pd.concat(user_dfs, axis=0)
-    df.reset_index(inplace=True, drop=True)
+    df = df.reset_index(drop=True)
+    if index:
+        df = df.set_index([ini.Columns.datetime, ini.Columns.id])
     return df
 
 

--- a/timeserio/keras/multinetwork.py
+++ b/timeserio/keras/multinetwork.py
@@ -71,11 +71,17 @@ class MultiNetworkBase(abc.ABC):
     @property
     def _funcs_with_legal_params(self):
         Sequential = keras.models.Sequential
-        return [
+        methods = [
             Sequential.fit, Sequential.fit_generator, Sequential.predict,
-            Sequential.predict_classes, Sequential.evaluate, self._model,
-            self._callbacks
+            Sequential.predict_classes, Sequential.evaluate
         ]
+        # fix for tensorflow 2.2.0 using method wrappers
+        # these were removed again in 2.3.0
+        unwrapped_methods = [
+            getattr(method, "__wrapped__", method)
+            for method in methods
+        ]
+        return [*unwrapped_methods, self._model, self._callbacks]
 
     @property
     def _funcs_with_default_params(self):
@@ -103,6 +109,7 @@ class MultiNetworkBase(abc.ABC):
         """
         override = override or {}
         res = {}
+        fn = getattr(fn, "__wrapped__", fn)
         for name, value in self.hyperparams.items():
             if has_arg(fn, name):
                 res.update({name: value})

--- a/timeserio/keras/multinetwork.py
+++ b/timeserio/keras/multinetwork.py
@@ -78,7 +78,7 @@ class MultiNetworkBase(abc.ABC):
         # fix for tensorflow 2.2.0 using method wrappers
         # these were removed again in 2.3.0
         unwrapped_methods = [
-            getattr(method, "__wrapped__", method)
+            getattr(method, "__wrapped__", default=method)
             for method in methods
         ]
         return [*unwrapped_methods, self._model, self._callbacks]
@@ -109,7 +109,7 @@ class MultiNetworkBase(abc.ABC):
         """
         override = override or {}
         res = {}
-        fn = getattr(fn, "__wrapped__", fn)
+        fn = getattr(fn, "__wrapped__", default=fn)
         for name, value in self.hyperparams.items():
             if has_arg(fn, name):
                 res.update({name: value})

--- a/timeserio/keras/utils.py
+++ b/timeserio/keras/utils.py
@@ -56,17 +56,17 @@ def seed_random(seed=42):
     os.environ['CUDA_VISIBLE_DEVICES'] = ''
     py_random.seed(seed)
     np.random.seed(seed)
-    tf.reset_default_graph()
+    tf.compat.v1.reset_default_graph()
 
     graph = tf.Graph()
-    config = tf.ConfigProto(
+    config = tf.compat.v1.ConfigProto(
         intra_op_parallelism_threads=1,
         inter_op_parallelism_threads=1,
     )
-    session = tf.Session(graph=graph, config=config)
-    keras.backend.set_session(session)
+    session = tf.compat.v1.Session(graph=graph, config=config)
+    tf.compat.v1.keras.backend.set_session(session)
     with tf.device("/cpu:0"), graph.as_default(), session.as_default():
-        tf.set_random_seed(seed)
+        tf.compat.v1.set_random_seed(seed)
         graph.seed = seed
         yield
-    keras.backend.clear_session()
+    tf.compat.v1.keras.backend.clear_session()

--- a/timeserio/preprocessing/__init__.py
+++ b/timeserio/preprocessing/__init__.py
@@ -4,6 +4,7 @@ from .encoding import (FeatureIndexEncoder,  # noqa
                        StatelessTemporalOneHotEncoder)
 from .pandas import (PandasColumnSelector,  # noqa
                      PandasValueSelector,
+                     PandasIndexValueSelector,
                      PandasSequenceSplitter)
 from .datetime import PandasDateTimeFeaturizer, LagFeaturizer, RollingMeanFeaturizer  # noqa
 from .aggregate import AggregateFeaturizer  # noqa

--- a/timeserio/preprocessing/pandas.py
+++ b/timeserio/preprocessing/pandas.py
@@ -111,6 +111,31 @@ class PandasValueSelector(BaseEstimator, TransformerMixin):
         return {None}
 
 
+class PandasIndexValueSelector(BaseEstimator, TransformerMixin):
+    """Select index levels as feature cols, and return np.array."""
+
+    def __init__(self, levels=None):
+        self.levels = levels
+
+    def fit(self, df, y=None, **fit_params):
+        return self
+
+    def transform(self, df):
+        levels = self.levels or []
+        if isinstance(levels, str):
+            levels = [levels]
+        try:
+            iter(levels)
+        except TypeError:
+            levels = [levels]
+        blocks = [
+            df.index.get_level_values(level).values.reshape(-1, 1)
+            for level in levels
+        ]
+        subarray = np.hstack(blocks) if blocks else np.empty((len(df), 0))
+        return subarray
+
+
 class PandasSequenceSplitter(BaseEstimator, TransformerMixin):
     """Split sequence columns in two."""
 


### PR DESCRIPTION
Before this change, introspection of args compatible with e.g. Sequential.fit would fail
if that method was wrapped with a decorator that itself uses *args, **kwargs - specifically,
this is the case in TF2.2.0

After this change, relevant methods are un-wrapped as needed.

The issue was introduced in https://github.com/tensorflow/tensorflow/commit/10666c59dd4858645d1b03ce01f4450da80710ec but resolved again in TF2.3
